### PR TITLE
Build runnable Q-Cap MVP with revocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -65,7 +65,7 @@ checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -94,6 +94,12 @@ dependencies = [
  "predicates-tree",
  "wait-timeout",
 ]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -344,6 +350,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,7 +392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -404,6 +421,15 @@ checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]
@@ -452,6 +478,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +611,18 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
@@ -518,6 +658,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +682,24 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -579,13 +743,19 @@ name = "qcap-cli"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "blake3",
+ "chacha20poly1305",
  "clap",
  "ed25519-dalek",
  "hex",
  "qcap-core",
+ "rand",
+ "serde",
  "serde_json",
  "tempfile",
+ "ureq",
  "walkdir",
+ "x25519-dalek",
  "zip",
 ]
 
@@ -597,12 +767,14 @@ dependencies = [
  "chacha20poly1305",
  "ed25519-dalek",
  "hex",
+ "rand",
  "rand_core",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
  "walkdir",
+ "x25519-dalek",
  "zip",
 ]
 
@@ -622,6 +794,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +828,20 @@ name = "regex-automata"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rustc_version"
@@ -655,7 +862,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -749,6 +991,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +1005,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -782,6 +1036,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,7 +1056,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -821,6 +1086,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +1116,48 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -889,12 +1206,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -905,11 +1240,36 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -919,15 +1279,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -937,9 +1303,21 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -949,9 +1327,21 @@ checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -961,15 +1351,33 @@ checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -984,10 +1392,139 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zip"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +408,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +487,24 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]
@@ -607,6 +649,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +725,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "poly1305"
@@ -750,6 +809,7 @@ dependencies = [
  "hex",
  "qcap-core",
  "rand",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
@@ -841,6 +901,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -1164,6 +1238,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/README.md
+++ b/README.md
@@ -165,10 +165,11 @@ The current MVP demonstrates the core Q-Cap flow locally:
 
 1. Generate issuer and recipient identities.
 2. Seal a payload directory into an encrypted `.qcap`.
-3. Publish and fetch it through the local registry.
-4. Prove open fails without a capability.
-5. Grant a capability for `reports/*`.
-6. Open only the authorized payload path.
+3. Include a generated sample GeoPackage at `reports/observations.gpkg`.
+4. Publish and fetch it through the local registry.
+5. Prove open fails without a capability.
+6. Grant a capability for `reports/*`.
+7. Open only the authorized payload path and verify the GeoPackage exports unchanged.
 
 On Windows PowerShell:
 
@@ -181,6 +182,7 @@ Manual equivalent:
 ```bash
 cargo run -p qcap-cli -- init --name issuer --out /tmp/qcap-demo/issuer.identity.json
 cargo run -p qcap-cli -- init --name recipient --out /tmp/qcap-demo/recipient.identity.json
+cargo run -p qcap-cli -- sample-geopackage --out /tmp/qcap-demo/payload/reports/observations.gpkg
 cargo run -p qcap-cli -- seal /tmp/qcap-demo/payload --issuer /tmp/qcap-demo/issuer.identity.json --recipient /tmp/qcap-demo/recipient.identity.json --out /tmp/qcap-demo/demo.qcap
 QCAP_REGISTRY_SEED=/tmp/qcap-demo/registry go run services/qcap-registry/main.go
 cargo run -p qcap-cli -- publish /tmp/qcap-demo/demo.qcap --registry http://127.0.0.1:8080
@@ -285,9 +287,17 @@ A `.qcap` is a **single file** (ZIP or tar+gz) containing:
 
 ## Geospatial & GeoPackage
 
-Q-Cap is payload-agnostic but designed to carry geospatial content. The MVP will document how to:
+Q-Cap is payload-agnostic but designed to carry geospatial content. The MVP includes a concrete GeoPackage fixture:
 
-* Transport **GeoPackage** unchanged inside `.qcap`
+```bash
+cargo run -p qcap-cli -- sample-geopackage --out /tmp/qcap-demo/payload/reports/observations.gpkg
+```
+
+The generated file is a valid SQLite-backed GeoPackage with one WGS 84 point feature. The MVP demo seals it inside `.qcap`, grants access to `reports/*`, opens the package, and verifies the exported GeoPackage is byte-for-byte unchanged.
+
+The format supports:
+
+* Transporting **GeoPackage** unchanged inside `.qcap`
 * Embed STAC/OGC metadata in `meta/`
 * Stream-verify large rasters via Merkle while fetching ranges
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,38 @@ cargo run -p qcap-cli -- hash "hello world"
 # -> blake3:7d8d... (hash will vary)
 ```
 
+### MVP demo: sealed package, capability, registry
+
+The current MVP demonstrates the core Q-Cap flow locally:
+
+1. Generate issuer and recipient identities.
+2. Seal a payload directory into an encrypted `.qcap`.
+3. Publish and fetch it through the local registry.
+4. Prove open fails without a capability.
+5. Grant a capability for `reports/*`.
+6. Open only the authorized payload path.
+
+On Windows PowerShell:
+
+```powershell
+.\scripts\demo.ps1
+```
+
+Manual equivalent:
+
+```bash
+cargo run -p qcap-cli -- init --name issuer --out /tmp/qcap-demo/issuer.identity.json
+cargo run -p qcap-cli -- init --name recipient --out /tmp/qcap-demo/recipient.identity.json
+cargo run -p qcap-cli -- seal /tmp/qcap-demo/payload --issuer /tmp/qcap-demo/issuer.identity.json --recipient /tmp/qcap-demo/recipient.identity.json --out /tmp/qcap-demo/demo.qcap
+QCAP_REGISTRY_SEED=/tmp/qcap-demo/registry go run services/qcap-registry/main.go
+cargo run -p qcap-cli -- publish /tmp/qcap-demo/demo.qcap --registry http://127.0.0.1:8080
+cargo run -p qcap-cli -- fetch demo.qcap --out /tmp/qcap-demo/fetched.qcap --registry http://127.0.0.1:8080
+cargo run -p qcap-cli -- grant /tmp/qcap-demo/fetched.qcap --issuer /tmp/qcap-demo/issuer.identity.json --audience <recipient-id> --path "reports/*" --out /tmp/qcap-demo/cap.json
+cargo run -p qcap-cli -- open /tmp/qcap-demo/fetched.qcap --cap /tmp/qcap-demo/cap.json --identity /tmp/qcap-demo/recipient.identity.json --out /tmp/qcap-demo/exported
+```
+
+This is an MVP, not a hardened security product. It uses XChaCha20-Poly1305 for file encryption, X25519-derived wrapping keys for recipients, ed25519 signatures over the Merkle root, and signed capability tokens with enforced expiry, audience, and path constraints.
+
 ### Run the registry (dev)
 
 You can seed demo capsules and run the registry locally. It exposes:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ flowchart LR
 
   %% --- Core Library ---
   subgraph Core["qcap-core (Rust)"]
-    CORE["Crypto • Merkle (BLAKE3) • Capabilities (macaroons)\nAEAD: XChaCha20-Poly1305 • ed25519 • Argon2id"]
+    CORE["Crypto • Merkle (BLAKE3) • Capabilities (macaroons)\nAEAD: XChaCha20-Poly1305 • ed25519 • planned Argon2id keyfiles"]
   end
 
   %% --- Consumers / SDKs ---
@@ -166,10 +166,12 @@ The current MVP demonstrates the core Q-Cap flow locally:
 1. Generate issuer and recipient identities.
 2. Seal a payload directory into an encrypted `.qcap`.
 3. Include a generated sample GeoPackage at `reports/observations.gpkg`.
-4. Publish and fetch it through the local registry.
-5. Prove open fails without a capability.
-6. Grant a capability for `reports/*`.
-7. Open only the authorized payload path and verify the GeoPackage exports unchanged.
+4. Verify the sealed archive.
+5. Publish and fetch it through the token-protected local registry.
+6. Prove open fails without a capability.
+7. Grant a capability for `reports/*`.
+8. Open only the authorized payload path and verify the GeoPackage exports unchanged.
+9. Revoke the capability and prove the revoked token is blocked.
 
 On Windows PowerShell:
 
@@ -184,11 +186,14 @@ cargo run -p qcap-cli -- init --name issuer --out /tmp/qcap-demo/issuer.identity
 cargo run -p qcap-cli -- init --name recipient --out /tmp/qcap-demo/recipient.identity.json
 cargo run -p qcap-cli -- sample-geopackage --out /tmp/qcap-demo/payload/reports/observations.gpkg
 cargo run -p qcap-cli -- seal /tmp/qcap-demo/payload --issuer /tmp/qcap-demo/issuer.identity.json --recipient /tmp/qcap-demo/recipient.identity.json --out /tmp/qcap-demo/demo.qcap
-QCAP_REGISTRY_SEED=/tmp/qcap-demo/registry go run services/qcap-registry/main.go
-cargo run -p qcap-cli -- publish /tmp/qcap-demo/demo.qcap --registry http://127.0.0.1:8080
+cargo run -p qcap-cli -- verify /tmp/qcap-demo/demo.qcap
+QCAP_REGISTRY_SEED=/tmp/qcap-demo/registry QCAP_REGISTRY_TOKEN=demo-token go run services/qcap-registry/main.go
+cargo run -p qcap-cli -- publish /tmp/qcap-demo/demo.qcap --registry http://127.0.0.1:8080 --token demo-token
 cargo run -p qcap-cli -- fetch demo.qcap --out /tmp/qcap-demo/fetched.qcap --registry http://127.0.0.1:8080
 cargo run -p qcap-cli -- grant /tmp/qcap-demo/fetched.qcap --issuer /tmp/qcap-demo/issuer.identity.json --audience <recipient-id> --path "reports/*" --out /tmp/qcap-demo/cap.json
 cargo run -p qcap-cli -- open /tmp/qcap-demo/fetched.qcap --cap /tmp/qcap-demo/cap.json --identity /tmp/qcap-demo/recipient.identity.json --out /tmp/qcap-demo/exported
+cargo run -p qcap-cli -- revoke --cap /tmp/qcap-demo/cap.json --issuer /tmp/qcap-demo/issuer.identity.json --out /tmp/qcap-demo/revocations.json
+cargo run -p qcap-cli -- open /tmp/qcap-demo/fetched.qcap --cap /tmp/qcap-demo/cap.json --identity /tmp/qcap-demo/recipient.identity.json --revocations /tmp/qcap-demo/revocations.json --out /tmp/qcap-demo/revoked-exported
 ```
 
 This is an MVP, not a hardened security product. It uses XChaCha20-Poly1305 for file encryption, X25519-derived wrapping keys for recipients, ed25519 signatures over the Merkle root, and signed capability tokens with enforced expiry, audience, and path constraints.
@@ -204,14 +209,16 @@ You can seed demo capsules and run the registry locally. It exposes:
 * `/index` — HTML index listing
 * `/artifacts/<name>` — static download of seeded artifacts
 
+Set `QCAP_REGISTRY_TOKEN` to require `Authorization: Bearer <token>` for `POST /artifacts`. The registry persists artifact metadata to `index.json` in the store directory by default.
+
 Quick start:
 
 ```bash
 # Seed demo artifacts (alpha.qcap, beta.qcap)
 scripts/seed-registry.sh
 
-# Run the registry
-go run services/qcap-registry/main.go
+# Run the registry with publish auth
+QCAP_REGISTRY_TOKEN=demo-token go run services/qcap-registry/main.go
 
 # Optional: smoke test endpoints
 scripts/smoke-registry.sh
@@ -231,7 +238,7 @@ npm run build
 
 Planned commands and features (tracked in GitHub Issues):
 
-* `qcap init` — local key material (Argon2id-protected), fingerprint printout
+* `qcap init` — local MVP identity/key material, fingerprint printout
 * `qcap pack` — create `.qcap` archive with `manifest.json`, `payload/`, `meta/`
 * `qcap seal` — per-file XChaCha20-Poly1305 envelope encryption, recipients
 * `qcap open` — verify + decrypt with capability; caveats enforced
@@ -272,10 +279,10 @@ A `.qcap` is a **single file** (ZIP or tar+gz) containing:
 ## Security model (high level)
 
 * Memory-safe languages (Rust core; Go service)
-* Modern crypto defaults (XChaCha20-Poly1305, BLAKE3, ed25519, Argon2id)
+* Modern crypto defaults in the MVP flow (XChaCha20-Poly1305, BLAKE3, ed25519)
 * Keys:
 
-  * Dev: encrypted keyfiles
+  * Dev: local identity JSON; Argon2id-protected keyfiles are planned
   * Prod: cloud KMS / HSM for issuer roots; rotation documented
 * Supply chain:
 

--- a/core/qcap-cli/Cargo.toml
+++ b/core/qcap-cli/Cargo.toml
@@ -19,6 +19,7 @@ chacha20poly1305 = "0.10"
 rand = "0.8"
 x25519-dalek = { version = "2", features = ["static_secrets"] }
 ureq = { version = "2", features = ["json"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/core/qcap-cli/Cargo.toml
+++ b/core/qcap-cli/Cargo.toml
@@ -10,9 +10,15 @@ qcap-core = { path = "../qcap-core" }
 hex = "0.4"
 ed25519-dalek = { version = "2" }
 serde_json = "1"
+serde = { version = "1", features = ["derive"] }
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 tempfile = "3"
 walkdir = "2"
+blake3 = "1"
+chacha20poly1305 = "0.10"
+rand = "0.8"
+x25519-dalek = { version = "2", features = ["static_secrets"] }
+ureq = { version = "2", features = ["json"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/core/qcap-cli/Cargo.toml
+++ b/core/qcap-cli/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 qcap-core = { path = "../qcap-core" }
 hex = "0.4"
 ed25519-dalek = { version = "2" }

--- a/core/qcap-cli/src/main.rs
+++ b/core/qcap-cli/src/main.rs
@@ -14,6 +14,7 @@ use qcap_core::payload_merkle::compute_payload_merkle_root;
 use qcap_core::signatures::{sign_merkle_root, verify_signature, QcapSignatureBundle};
 use rand::rngs::OsRng;
 use rand::RngCore;
+use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 use tempfile::tempdir;
 use walkdir::WalkDir;
@@ -102,6 +103,11 @@ enum Commands {
         #[arg(long = "registry", default_value = "http://127.0.0.1:8080")]
         registry: String,
     },
+    /// Create a tiny valid GeoPackage fixture for MVP demos and tests
+    SampleGeopackage {
+        #[arg(short = 'o', long = "out")]
+        out: PathBuf,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -178,6 +184,7 @@ fn run() -> Result<()> {
             out,
             registry,
         } => fetch(&artifact, &out, &registry)?,
+        Commands::SampleGeopackage { out } => sample_geopackage(&out)?,
     }
     Ok(())
 }
@@ -531,6 +538,132 @@ fn fetch(artifact: &str, out: &Path, registry: &str) -> Result<()> {
         out.display()
     );
     Ok(())
+}
+
+fn sample_geopackage(out: &Path) -> Result<()> {
+    if let Some(parent) = out.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    if out.exists() {
+        fs::remove_file(out)?;
+    }
+
+    let conn = Connection::open(out)?;
+    conn.pragma_update(None, "application_id", 0x4750_4b47i64)?;
+    conn.pragma_update(None, "user_version", 10_300i64)?;
+    conn.execute_batch(
+        r#"
+        CREATE TABLE gpkg_spatial_ref_sys (
+            srs_name TEXT NOT NULL,
+            srs_id INTEGER NOT NULL PRIMARY KEY,
+            organization TEXT NOT NULL,
+            organization_coordsys_id INTEGER NOT NULL,
+            definition TEXT NOT NULL,
+            description TEXT
+        );
+
+        CREATE TABLE gpkg_contents (
+            table_name TEXT NOT NULL PRIMARY KEY,
+            data_type TEXT NOT NULL,
+            identifier TEXT UNIQUE,
+            description TEXT DEFAULT '',
+            last_change DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            min_x DOUBLE,
+            min_y DOUBLE,
+            max_x DOUBLE,
+            max_y DOUBLE,
+            srs_id INTEGER,
+            CONSTRAINT fk_gc_r_srs_id FOREIGN KEY (srs_id)
+                REFERENCES gpkg_spatial_ref_sys(srs_id)
+        );
+
+        CREATE TABLE gpkg_geometry_columns (
+            table_name TEXT NOT NULL,
+            column_name TEXT NOT NULL,
+            geometry_type_name TEXT NOT NULL,
+            srs_id INTEGER NOT NULL,
+            z TINYINT NOT NULL,
+            m TINYINT NOT NULL,
+            PRIMARY KEY (table_name, column_name),
+            CONSTRAINT fk_ggc_tn FOREIGN KEY (table_name)
+                REFERENCES gpkg_contents(table_name),
+            CONSTRAINT fk_ggc_srs FOREIGN KEY (srs_id)
+                REFERENCES gpkg_spatial_ref_sys(srs_id)
+        );
+
+        CREATE TABLE observations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            geom BLOB NOT NULL
+        );
+        "#,
+    )?;
+
+    conn.execute(
+        "INSERT INTO gpkg_spatial_ref_sys VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            "Undefined Cartesian SRS",
+            -1i64,
+            "NONE",
+            -1i64,
+            "undefined",
+            "undefined Cartesian coordinate reference system"
+        ],
+    )?;
+    conn.execute(
+        "INSERT INTO gpkg_spatial_ref_sys VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            "Undefined geographic SRS",
+            0i64,
+            "NONE",
+            0i64,
+            "undefined",
+            "undefined geographic coordinate reference system"
+        ],
+    )?;
+    conn.execute(
+        "INSERT INTO gpkg_spatial_ref_sys VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            "WGS 84 geodetic",
+            4326i64,
+            "EPSG",
+            4326i64,
+            "GEOGCS[\"WGS 84\",DATUM[\"World Geodetic System 1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433]]",
+            "longitude/latitude coordinates in decimal degrees"
+        ],
+    )?;
+    conn.execute(
+        "INSERT INTO gpkg_contents (table_name, data_type, identifier, description, last_change, min_x, min_y, max_x, max_y, srs_id)
+         VALUES ('observations', 'features', 'observations', 'Q-Cap MVP sample point layer', '2026-06-27T00:00:00.000Z', -123.1207, 49.2827, -123.1207, 49.2827, 4326)",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO gpkg_geometry_columns VALUES ('observations', 'geom', 'POINT', 4326, 0, 0)",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO observations (name, geom) VALUES (?1, ?2)",
+        params![
+            "Vancouver sample point",
+            geopackage_point_blob(-123.1207, 49.2827)
+        ],
+    )?;
+
+    println!("GeoPackage created\n- output: {}", out.display());
+    Ok(())
+}
+
+fn geopackage_point_blob(x: f64, y: f64) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(29);
+    bytes.extend_from_slice(b"GP");
+    bytes.push(0);
+    bytes.push(1);
+    bytes.extend_from_slice(&4326i32.to_le_bytes());
+    bytes.push(1);
+    bytes.extend_from_slice(&1u32.to_le_bytes());
+    bytes.extend_from_slice(&x.to_le_bytes());
+    bytes.extend_from_slice(&y.to_le_bytes());
+    bytes
 }
 
 #[derive(Deserialize)]

--- a/core/qcap-cli/src/main.rs
+++ b/core/qcap-cli/src/main.rs
@@ -1,277 +1,786 @@
-use clap::{Parser, Subcommand};
 use std::fs;
-use std::path::PathBuf;
-
-use ed25519_dalek::SigningKey;
-use qcap_core::manifest::QcapManifest;
-use qcap_core::payload_merkle::compute_payload_merkle_root;
-use qcap_core::signatures::{sign_merkle_root, QcapSignatureBundle, verify_signature};
-use qcap_core::capabilities::CapabilityToken;
-use qcap_core::archive::create_qcap_archive_with_signature;
-use zip::read::ZipArchive;
 use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use chacha20poly1305::aead::{Aead, KeyInit, Payload};
+use chacha20poly1305::{Key, XChaCha20Poly1305, XNonce};
+use clap::{Parser, Subcommand};
+use ed25519_dalek::SigningKey;
+use qcap_core::archive::create_qcap_archive_with_signature;
+use qcap_core::capabilities::CapabilityToken;
+use qcap_core::manifest::{PayloadFile, QcapManifest, RecipientStanza};
+use qcap_core::payload_merkle::compute_payload_merkle_root;
+use qcap_core::signatures::{sign_merkle_root, verify_signature, QcapSignatureBundle};
+use rand::rngs::OsRng;
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
 use tempfile::tempdir;
+use walkdir::WalkDir;
+use x25519_dalek::{PublicKey, StaticSecret};
+use zip::read::ZipArchive;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 #[derive(Parser)]
-#[command(name = "qcap", version, about = "Q-Cap CLI (alpha)")]
-struct Cli { #[command(subcommand)] command: Commands }
+#[command(name = "qcap", version, about = "Q-Cap CLI (MVP)")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
 
 #[derive(Subcommand)]
 enum Commands {
     /// Demo: hash input bytes
     Hash { input: String },
-    /// Pack a directory into a .qcap archive
-    Pack {
-        /// Input directory to include under payload/
-        input_dir: PathBuf,
-        /// Output .qcap file path
+    /// Generate a local identity with signing and recipient encryption keys
+    Init {
         #[arg(short = 'o', long = "out")]
         out: PathBuf,
-        /// Ed25519 private key file (32-byte seed hex or pkcs8 DER not supported yet)
+        #[arg(long = "name", default_value = "local")]
+        name: String,
+    },
+    /// Pack a plaintext directory into a signed .qcap archive
+    Pack {
+        input_dir: PathBuf,
+        #[arg(short = 'o', long = "out")]
+        out: PathBuf,
         #[arg(short = 'k', long = "key")]
         key: PathBuf,
+    },
+    /// Seal a directory into an encrypted .qcap archive for a recipient
+    Seal {
+        input_dir: PathBuf,
+        #[arg(short = 'o', long = "out")]
+        out: PathBuf,
+        #[arg(long = "issuer")]
+        issuer: PathBuf,
+        #[arg(long = "recipient")]
+        recipient: PathBuf,
     },
     /// Verify a .qcap archive
-    Verify {
-        /// Input .qcap file
-        file: PathBuf,
-    },
+    Verify { file: PathBuf },
     /// Inspect a .qcap archive and print summary
-    Inspect {
-        /// Input .qcap file
-        file: PathBuf,
-    },
-    /// Grant a capability token bound to a .qcap's merkle root
+    Inspect { file: PathBuf },
+    /// Grant a capability token bound to a .qcap's Merkle root
     Grant {
-        /// Input .qcap file
         file: PathBuf,
-        /// Allow operation (e.g., read)
         #[arg(long = "allow", default_value = "read")]
         allow: String,
-        /// Expiry timestamp (unix-seconds:<ts> for MVP)
+        #[arg(long = "path", default_value = "*")]
+        path: String,
+        #[arg(long = "audience")]
+        audience: String,
         #[arg(long = "expires", default_value = "unix-seconds:9999999999")]
         expires: String,
-        /// Ed25519 private key seed hex
-        #[arg(short = 'k', long = "key")]
-        key: PathBuf,
-        /// Output cap token path (JSON)
+        #[arg(long = "issuer")]
+        issuer: PathBuf,
         #[arg(short = 'o', long = "out")]
         out: PathBuf,
     },
-    /// Open a .qcap after verifying a capability token, exporting payload
+    /// Open a .qcap after verifying a capability token, exporting allowed payload
     Open {
-        /// Input .qcap file
         file: PathBuf,
-        /// Capability token JSON path
         #[arg(long = "cap")]
         cap: PathBuf,
-        /// Output directory to export payload
+        #[arg(long = "identity")]
+        identity: PathBuf,
         #[arg(short = 'o', long = "out")]
         out: PathBuf,
+    },
+    /// Publish a .qcap to a registry
+    Publish {
+        file: PathBuf,
+        #[arg(long = "registry", default_value = "http://127.0.0.1:8080")]
+        registry: String,
+    },
+    /// Fetch a .qcap from a registry
+    Fetch {
+        artifact: String,
+        #[arg(short = 'o', long = "out")]
+        out: PathBuf,
+        #[arg(long = "registry", default_value = "http://127.0.0.1:8080")]
+        registry: String,
     },
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct Identity {
+    name: String,
+    signing_seed: String,
+    signing_public_key: String,
+    encryption_secret: String,
+    encryption_public_key: String,
+}
+
 fn main() {
+    if let Err(err) = run() {
+        eprintln!("error: {err}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Commands::Hash { input } => {
-            let root = qcap_core::merkle_root_demo(input.as_bytes());
-            println!("{}", root);
-    }
-        Commands::Pack { input_dir, out, key } => {
-            // Compute merkle root over payload
-            let root = compute_payload_merkle_root(&input_dir).expect("merkle root");
-
-            // Build manifest
-            let manifest = QcapManifest::new_with_now(
-                "0.1.0",
-                &root,
-                None,
-                serde_json::json!({}),
-            );
-
-            // Load private key (hex seed of 32 bytes)
-            let key_hex = fs::read_to_string(&key).expect("read key file");
-            let key_hex = key_hex.trim();
-            let seed = hex::decode(key_hex).expect("decode hex seed");
-            assert_eq!(seed.len(), 32, "expected 32-byte seed hex");
-            let mut seed_arr = [0u8; 32];
-            seed_arr.copy_from_slice(&seed);
-            let signing_key = SigningKey::from_bytes(&seed_arr);
-
-            // Sign merkle root
-            let sig_bundle = sign_merkle_root(&root, &signing_key);
-
-            // Create archive with signature
-            create_qcap_archive_with_signature(&input_dir, &manifest, &sig_bundle, &out)
-                .expect("create archive");
-            println!("Packed {}\n- merkle root: {}\n- output: {}", input_dir.display(), root, out.display());
+            println!("{}", qcap_core::merkle_root_demo(input.as_bytes()));
         }
-        Commands::Verify { file } => {
-            // Open zip
-            let f = fs::File::open(&file).expect("open qcap");
-            let mut zip = ZipArchive::new(f).expect("zip");
-
-            // Read manifest.json
-            let manifest: QcapManifest = {
-                let mut mf = zip.by_name("manifest.json").expect("manifest.json");
-                let mut mstr = String::new();
-                mf.read_to_string(&mut mstr).expect("manifest read");
-                serde_json::from_str(&mstr).expect("manifest parse")
-            };
-
-            // Read signature bundle
-            let sig: QcapSignatureBundle = {
-                let mut sf = zip.by_name("signatures/manifest.sig.json").expect("sig bundle");
-                let mut sstr = String::new();
-                sf.read_to_string(&mut sstr).expect("sig read");
-                serde_json::from_str(&sstr).expect("sig parse")
-            };
-
-            // Extract payload into temp dir
-            let tmp = tempdir().expect("tempdir");
-            let out_dir = tmp.path();
-            let mut payload_files = 0usize;
-            for i in 0..zip.len() {
-                let mut entry = zip.by_index(i).expect("entry");
-                let name = entry.name().to_string();
-                if name.starts_with("payload/") {
-                    // strip payload/
-                    let rel = &name[8..];
-                    let dest = out_dir.join(rel);
-                    if entry.is_dir() {
-                        fs::create_dir_all(&dest).ok();
-                    } else {
-                        if let Some(parent) = dest.parent() { fs::create_dir_all(parent).ok(); }
-                        let mut buf = Vec::new();
-                        entry.read_to_end(&mut buf).expect("read payload entry");
-                        fs::write(&dest, &buf).expect("write payload entry");
-                        payload_files += 1;
-                    }
-                }
-            }
-
-            // Recompute merkle root
-            let recomputed = compute_payload_merkle_root(out_dir).expect("recompute merkle");
-
-            // Checks
-            let roots_match = recomputed == manifest.merkle_root && recomputed == sig.merkle_root;
-            let sig_ok = verify_signature(&sig).is_ok();
-
-            if roots_match && sig_ok {
-                println!("Verification: OK\n- merkle root: {}\n- signer: {}\n- payload files: {}", recomputed, &sig.public_key[0..16], payload_files);
-            } else {
-                println!("Verification: FAILED\n- recomputed: {}\n- manifest: {}\n- bundle: {}\n- signature_ok: {}", recomputed, manifest.merkle_root, sig.merkle_root, sig_ok);
-                std::process::exit(1);
-            }
-        }
-        Commands::Inspect { file } => {
-            // Open zip
-            let f = fs::File::open(&file).expect("open qcap");
-            let mut zip = ZipArchive::new(f).expect("zip");
-
-            // Read manifest.json
-            let manifest: QcapManifest = {
-                let mut mf = zip.by_name("manifest.json").expect("manifest.json");
-                let mut mstr = String::new();
-                mf.read_to_string(&mut mstr).expect("manifest read");
-                serde_json::from_str(&mstr).expect("manifest parse")
-            };
-
-            // Read signature bundle (optional; if missing, treat as unknown)
-            let sig_summary = if let Ok(mut sf) = zip.by_name("signatures/manifest.sig.json") {
-                let mut sstr = String::new();
-                sf.read_to_string(&mut sstr).ok();
-                if let Ok(sig) = serde_json::from_str::<QcapSignatureBundle>(&sstr) {
-                    format!("{}", &sig.public_key.chars().take(16).collect::<String>())
-                } else {
-                    "(unreadable)".to_string()
-                }
-            } else {
-                "(none)".to_string()
-            };
-
-            // Count payload files without extraction
-            let mut payload_files = 0usize;
-            for i in 0..zip.len() {
-                let entry = zip.by_index(i).expect("entry");
-                let name = entry.name().to_string();
-                if name.starts_with("payload/") && !entry.is_dir() {
-                    payload_files += 1;
-                }
-            }
-
+        Commands::Init { out, name } => {
+            let identity = Identity::generate(name);
+            write_json(&out, &identity)?;
             println!(
-                "Q-Cap Inspect\n- schema_version: {}\n- merkle_root: {}\n- issuer: {}\n- created_at: {}\n- signer: {}\n- payload files: {}",
-                manifest.schema_version,
-                manifest.merkle_root,
-                manifest.issuer.as_deref().unwrap_or("(none)"),
-                manifest.created_at,
-                sig_summary,
-                payload_files
+                "Identity created\n- id: {}\n- out: {}",
+                identity.id(),
+                out.display()
             );
         }
-        Commands::Grant { file, allow, expires, key, out } => {
-            // Open zip and read manifest
-            let f = fs::File::open(&file).expect("open qcap");
-            let mut zip = ZipArchive::new(f).expect("zip");
-            let manifest: QcapManifest = {
-                let mut mf = zip.by_name("manifest.json").expect("manifest.json");
-                let mut mstr = String::new();
-                mf.read_to_string(&mut mstr).expect("manifest read");
-                serde_json::from_str(&mstr).expect("manifest parse")
-            };
-            // Load private key
-            let key_hex = fs::read_to_string(&key).expect("read key file");
-            let seed = hex::decode(key_hex.trim()).expect("hex");
-            assert_eq!(seed.len(), 32, "expected 32-byte seed");
-            let mut seed_arr = [0u8; 32];
-            seed_arr.copy_from_slice(&seed);
-            let signing_key = SigningKey::from_bytes(&seed_arr);
-            // Grant
-            let cap = CapabilityToken::grant(&manifest.merkle_root, &allow, &expires, &signing_key);
-            let json = serde_json::to_vec_pretty(&cap).expect("cap json");
-            fs::write(&out, &json).expect("write cap");
-            println!("Granted capability\n- cap_root: {}\n- allow: {}\n- expires: {}\n- out: {}", manifest.merkle_root, allow, expires, out.display());
+        Commands::Pack {
+            input_dir,
+            out,
+            key,
+        } => pack_plain(&input_dir, &out, &key)?,
+        Commands::Seal {
+            input_dir,
+            out,
+            issuer,
+            recipient,
+        } => seal(&input_dir, &out, &issuer, &recipient)?,
+        Commands::Verify { file } => {
+            let report = verify_archive(&file)?;
+            println!(
+                "Verification: OK\n- merkle root: {}\n- signer: {}\n- encrypted: {}\n- payload files: {}",
+                report.manifest.merkle_root,
+                report.signer_short(),
+                report.manifest.encrypted,
+                report.payload_files
+            );
         }
-        Commands::Open { file, cap, out } => {
-            // Read capability token and verify
-            let cap_bytes = fs::read(&cap).expect("read cap");
-            let cap: CapabilityToken = serde_json::from_slice(&cap_bytes).expect("parse cap");
-            cap.verify().expect("cap verify");
-            // Open archive, read manifest
-            let f = fs::File::open(&file).expect("open qcap");
-            let mut zip = ZipArchive::new(f).expect("zip");
-            let manifest: QcapManifest = {
-                let mut mf = zip.by_name("manifest.json").expect("manifest.json");
-                let mut mstr = String::new();
-                mf.read_to_string(&mut mstr).expect("manifest read");
-                serde_json::from_str(&mstr).expect("manifest parse")
-            };
-            // Ensure cap root matches manifest root and allow includes read
-            if cap.cap_root != manifest.merkle_root || cap.allow != "read" {
-                println!("Open: FAILED (cap mismatch or disallowed)");
-                std::process::exit(1);
-            }
-            // Export payload to out
-            fs::create_dir_all(&out).expect("create out");
-            for i in 0..zip.len() {
-                let mut entry = zip.by_index(i).expect("entry");
-                let name = entry.name().to_string();
-                if name.starts_with("payload/") {
-                    let rel = &name[8..];
-                    let dest = out.join(rel);
-                    if entry.is_dir() {
-                        fs::create_dir_all(&dest).ok();
-                    } else {
-                        if let Some(parent) = dest.parent() { fs::create_dir_all(parent).ok(); }
-                        let mut buf = Vec::new();
-                        entry.read_to_end(&mut buf).expect("read payload entry");
-                        fs::write(&dest, &buf).expect("write payload entry");
-                    }
-                }
-            }
-            println!("Open: OK\n- exported to: {}", out.display());
+        Commands::Inspect { file } => inspect(&file)?,
+        Commands::Grant {
+            file,
+            allow,
+            path,
+            audience,
+            expires,
+            issuer,
+            out,
+        } => grant(&file, &allow, &path, &audience, &expires, &issuer, &out)?,
+        Commands::Open {
+            file,
+            cap,
+            identity,
+            out,
+        } => open_archive(&file, &cap, &identity, &out)?,
+        Commands::Publish { file, registry } => publish(&file, &registry)?,
+        Commands::Fetch {
+            artifact,
+            out,
+            registry,
+        } => fetch(&artifact, &out, &registry)?,
+    }
+    Ok(())
+}
+
+impl Identity {
+    fn generate(name: String) -> Self {
+        let mut signing_seed = [0u8; 32];
+        OsRng.fill_bytes(&mut signing_seed);
+        let signing = SigningKey::from_bytes(&signing_seed);
+
+        let enc_secret = StaticSecret::random_from_rng(OsRng);
+        let enc_public = PublicKey::from(&enc_secret);
+
+        Self {
+            name,
+            signing_seed: hex::encode(signing_seed),
+            signing_public_key: hex::encode(signing.verifying_key().to_bytes()),
+            encryption_secret: hex::encode(enc_secret.to_bytes()),
+            encryption_public_key: hex::encode(enc_public.to_bytes()),
         }
     }
+
+    fn signing_key(&self) -> Result<SigningKey> {
+        let bytes = decode_32(&self.signing_seed, "signing_seed")?;
+        Ok(SigningKey::from_bytes(&bytes))
+    }
+
+    fn encryption_secret(&self) -> Result<StaticSecret> {
+        Ok(StaticSecret::from(decode_32(
+            &self.encryption_secret,
+            "encryption_secret",
+        )?))
+    }
+
+    fn encryption_public(&self) -> Result<PublicKey> {
+        Ok(PublicKey::from(decode_32(
+            &self.encryption_public_key,
+            "encryption_public_key",
+        )?))
+    }
+
+    fn id(&self) -> String {
+        self.signing_public_key.chars().take(16).collect()
+    }
+}
+
+struct VerifyReport {
+    manifest: QcapManifest,
+    signature: QcapSignatureBundle,
+    payload_files: usize,
+}
+
+impl VerifyReport {
+    fn signer_short(&self) -> String {
+        self.signature.public_key.chars().take(16).collect()
+    }
+}
+
+fn pack_plain(input_dir: &Path, out: &Path, key: &Path) -> Result<()> {
+    let root = compute_payload_merkle_root(input_dir)?;
+    let manifest = QcapManifest::new_with_now("0.1.0", &root, None, serde_json::json!({}));
+    let signing_key = signing_key_from_seed_file(key)?;
+    let sig_bundle = sign_merkle_root(&root, &signing_key);
+    create_qcap_archive_with_signature(input_dir, &manifest, &sig_bundle, out)?;
+    println!(
+        "Packed {}\n- merkle root: {}\n- output: {}",
+        input_dir.display(),
+        root,
+        out.display()
+    );
+    Ok(())
+}
+
+fn seal(input_dir: &Path, out: &Path, issuer_path: &Path, recipient_path: &Path) -> Result<()> {
+    if !input_dir.is_dir() {
+        return Err(format!("input_dir is not a directory: {}", input_dir.display()).into());
+    }
+
+    let issuer: Identity = read_json(issuer_path)?;
+    let recipient: Identity = read_json(recipient_path)?;
+    let mut content_key = [0u8; 32];
+    OsRng.fill_bytes(&mut content_key);
+    let package_id = random_id();
+
+    let tmp = tempdir()?;
+    let encrypted_root = tmp.path().join("payload");
+    fs::create_dir_all(&encrypted_root)?;
+    let mut files = Vec::new();
+
+    for abs in walk_files(input_dir)? {
+        let rel = rel_path(input_dir, &abs)?;
+        let plaintext = fs::read(&abs)?;
+        let mut nonce = [0u8; 24];
+        OsRng.fill_bytes(&mut nonce);
+        let ciphertext = encrypt(&content_key, &nonce, rel.as_bytes(), &plaintext)?;
+        let dest = encrypted_root.join(&rel);
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&dest, &ciphertext)?;
+        files.push(PayloadFile {
+            path: rel,
+            size: ciphertext.len() as u64,
+            nonce: hex::encode(nonce),
+            ciphertext_hash: blake3_prefixed(&ciphertext),
+        });
+    }
+
+    let merkle_root = compute_payload_merkle_root(&encrypted_root)?;
+    let recipients = vec![wrap_content_key(&content_key, &package_id, &recipient)?];
+    let manifest = QcapManifest::new_sealed(
+        "0.2.0",
+        package_id.clone(),
+        &merkle_root,
+        Some(issuer.id()),
+        serde_json::json!({ "title": "Q-Cap MVP sealed package" }),
+        files,
+        recipients,
+    );
+    let sig = sign_merkle_root(&merkle_root, &issuer.signing_key()?);
+
+    create_qcap_archive_with_signature(&encrypted_root, &manifest, &sig, out)?;
+    println!(
+        "Sealed {}\n- package id: {}\n- merkle root: {}\n- recipient: {}\n- output: {}",
+        input_dir.display(),
+        package_id,
+        merkle_root,
+        recipient.id(),
+        out.display()
+    );
+    Ok(())
+}
+
+fn grant(
+    file: &Path,
+    allow: &str,
+    path: &str,
+    audience: &str,
+    expires: &str,
+    issuer_path: &Path,
+    out: &Path,
+) -> Result<()> {
+    let report = verify_archive(file)?;
+    let issuer: Identity = read_json(issuer_path)?;
+    let allow_spec = format!("{allow};path={path};aud={audience}");
+    let cap = CapabilityToken::grant(
+        &report.manifest.merkle_root,
+        &allow_spec,
+        expires,
+        &issuer.signing_key()?,
+    );
+    write_json(out, &cap)?;
+    println!(
+        "Granted capability\n- cap_root: {}\n- allow: {}\n- path: {}\n- audience: {}\n- expires: {}\n- out: {}",
+        report.manifest.merkle_root,
+        allow,
+        path,
+        audience,
+        expires,
+        out.display()
+    );
+    Ok(())
+}
+
+fn open_archive(file: &Path, cap_path: &Path, identity_path: &Path, out: &Path) -> Result<()> {
+    let report = verify_archive(file)?;
+    let identity: Identity = read_json(identity_path)?;
+    let cap: CapabilityToken = read_json(cap_path)?;
+    cap.verify()?;
+
+    let access = Access::parse(&cap.allow)?;
+    if cap.cap_root != report.manifest.merkle_root {
+        return Err("capability root does not match archive".into());
+    }
+    if access.operation != "read" {
+        return Err("capability does not allow read".into());
+    }
+    if access.audience != identity.id() {
+        return Err("capability audience does not match identity".into());
+    }
+    enforce_expiry(&cap.expires)?;
+
+    fs::create_dir_all(out)?;
+    if report.manifest.encrypted {
+        open_encrypted(file, &report.manifest, &identity, &access, out)?;
+    } else {
+        open_plain(file, &access, out)?;
+    }
+    println!("Open: OK\n- exported to: {}", out.display());
+    Ok(())
+}
+
+fn open_encrypted(
+    file: &Path,
+    manifest: &QcapManifest,
+    identity: &Identity,
+    access: &Access,
+    out: &Path,
+) -> Result<()> {
+    let package_id = manifest
+        .package_id
+        .as_deref()
+        .ok_or("sealed archive missing package_id")?;
+    let stanza = manifest
+        .recipients
+        .iter()
+        .find(|r| r.recipient == identity.encryption_public_key)
+        .ok_or("identity is not a recipient for this archive")?;
+    let content_key = unwrap_content_key(stanza, package_id, identity)?;
+
+    let f = fs::File::open(file)?;
+    let mut zip = ZipArchive::new(f)?;
+    let mut exported = 0usize;
+    for spec in &manifest.files {
+        if !access.allows_path(&spec.path) {
+            continue;
+        }
+        let zip_name = format!("payload/{}", spec.path);
+        let mut entry = zip.by_name(&zip_name)?;
+        let mut ciphertext = Vec::new();
+        entry.read_to_end(&mut ciphertext)?;
+        if blake3_prefixed(&ciphertext) != spec.ciphertext_hash {
+            return Err(format!("ciphertext hash mismatch: {}", spec.path).into());
+        }
+        let nonce = decode_24(&spec.nonce, "file nonce")?;
+        let plaintext = decrypt(&content_key, &nonce, spec.path.as_bytes(), &ciphertext)?;
+        write_safe(out, &spec.path, &plaintext)?;
+        exported += 1;
+    }
+    if exported == 0 {
+        return Err("capability did not allow any files".into());
+    }
+    Ok(())
+}
+
+fn open_plain(file: &Path, access: &Access, out: &Path) -> Result<()> {
+    let f = fs::File::open(file)?;
+    let mut zip = ZipArchive::new(f)?;
+    let mut exported = 0usize;
+    for i in 0..zip.len() {
+        let mut entry = zip.by_index(i)?;
+        let name = entry.name().to_string();
+        if !name.starts_with("payload/") || entry.is_dir() {
+            continue;
+        }
+        let rel = &name[8..];
+        if !access.allows_path(rel) {
+            continue;
+        }
+        let mut bytes = Vec::new();
+        entry.read_to_end(&mut bytes)?;
+        write_safe(out, rel, &bytes)?;
+        exported += 1;
+    }
+    if exported == 0 {
+        return Err("capability did not allow any files".into());
+    }
+    Ok(())
+}
+
+fn verify_archive(file: &Path) -> Result<VerifyReport> {
+    let f = fs::File::open(file)?;
+    let mut zip = ZipArchive::new(f)?;
+    let manifest = read_manifest(&mut zip)?;
+    let signature = read_signature(&mut zip)?;
+    verify_signature(&signature)?;
+
+    let tmp = tempdir()?;
+    let mut payload_files = 0usize;
+    for i in 0..zip.len() {
+        let mut entry = zip.by_index(i)?;
+        let name = entry.name().to_string();
+        if !name.starts_with("payload/") || entry.is_dir() {
+            continue;
+        }
+        let rel = &name[8..];
+        let mut bytes = Vec::new();
+        entry.read_to_end(&mut bytes)?;
+        write_safe(tmp.path(), rel, &bytes)?;
+        payload_files += 1;
+    }
+
+    let recomputed = compute_payload_merkle_root(tmp.path())?;
+    if recomputed != manifest.merkle_root || recomputed != signature.merkle_root {
+        return Err(format!(
+            "Merkle root mismatch: recomputed={}, manifest={}, signature={}",
+            recomputed, manifest.merkle_root, signature.merkle_root
+        )
+        .into());
+    }
+
+    Ok(VerifyReport {
+        manifest,
+        signature,
+        payload_files,
+    })
+}
+
+fn inspect(file: &Path) -> Result<()> {
+    let report = verify_archive(file)?;
+    println!(
+        "Q-Cap Inspect\n- schema_version: {}\n- package_id: {}\n- merkle_root: {}\n- issuer: {}\n- created_at: {}\n- signer: {}\n- encrypted: {}\n- payload files: {}\n- recipients: {}",
+        report.manifest.schema_version,
+        report.manifest.package_id.as_deref().unwrap_or("(none)"),
+        report.manifest.merkle_root,
+        report.manifest.issuer.as_deref().unwrap_or("(none)"),
+        report.manifest.created_at,
+        report.signer_short(),
+        report.manifest.encrypted,
+        report.payload_files,
+        report.manifest.recipients.len()
+    );
+    Ok(())
+}
+
+fn publish(file: &Path, registry: &str) -> Result<()> {
+    let url = format!("{}/artifacts", registry.trim_end_matches('/'));
+    let bytes = fs::read(file)?;
+    let name = file
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or("artifact path has no UTF-8 file name")?;
+    let response: PublishResponse = ureq::post(&url)
+        .set("Content-Type", "application/qcap+zip")
+        .set("X-Qcap-Name", name)
+        .send_bytes(&bytes)?
+        .into_json()?;
+    println!(
+        "Published\n- artifact: {}\n- url: {}{}",
+        response.name,
+        registry.trim_end_matches('/'),
+        response.path
+    );
+    Ok(())
+}
+
+fn fetch(artifact: &str, out: &Path, registry: &str) -> Result<()> {
+    let artifact = artifact.trim_start_matches('/');
+    let url = format!(
+        "{}/artifacts/{}",
+        registry.trim_end_matches('/'),
+        artifact.trim_start_matches("artifacts/")
+    );
+    let response = ureq::get(&url).call()?;
+    let mut bytes = Vec::new();
+    response.into_reader().read_to_end(&mut bytes)?;
+    fs::write(out, bytes)?;
+    println!(
+        "Fetched\n- artifact: {}\n- out: {}",
+        artifact,
+        out.display()
+    );
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct PublishResponse {
+    name: String,
+    path: String,
+}
+
+#[derive(Debug)]
+struct Access {
+    operation: String,
+    path: String,
+    audience: String,
+}
+
+impl Access {
+    fn parse(input: &str) -> Result<Self> {
+        let mut parts = input.split(';');
+        let operation = parts.next().unwrap_or_default().to_string();
+        let mut path = "*".to_string();
+        let mut audience = String::new();
+        for part in parts {
+            if let Some(value) = part.strip_prefix("path=") {
+                path = value.to_string();
+            } else if let Some(value) = part.strip_prefix("aud=") {
+                audience = value.to_string();
+            }
+        }
+        if audience.is_empty() {
+            return Err("capability missing audience".into());
+        }
+        Ok(Self {
+            operation,
+            path,
+            audience,
+        })
+    }
+
+    fn allows_path(&self, candidate: &str) -> bool {
+        glob_match(&self.path, candidate)
+    }
+}
+
+fn wrap_content_key(
+    key: &[u8; 32],
+    package_id: &str,
+    recipient: &Identity,
+) -> Result<RecipientStanza> {
+    let recipient_public = recipient.encryption_public()?;
+    let ephemeral_secret = StaticSecret::random_from_rng(OsRng);
+    let ephemeral_public = PublicKey::from(&ephemeral_secret);
+    let shared = ephemeral_secret.diffie_hellman(&recipient_public);
+    let wrap_key = derive_wrap_key(shared.as_bytes(), package_id);
+    let mut nonce = [0u8; 24];
+    OsRng.fill_bytes(&mut nonce);
+    let wrapped = encrypt(&wrap_key, &nonce, package_id.as_bytes(), key)?;
+    Ok(RecipientStanza {
+        recipient: recipient.encryption_public_key.clone(),
+        ephemeral_public_key: hex::encode(ephemeral_public.to_bytes()),
+        nonce: hex::encode(nonce),
+        wrapped_key: hex::encode(wrapped),
+        algorithm: "x25519-blake3-xchacha20poly1305".to_string(),
+    })
+}
+
+fn unwrap_content_key(
+    stanza: &RecipientStanza,
+    package_id: &str,
+    identity: &Identity,
+) -> Result<[u8; 32]> {
+    let ephemeral = PublicKey::from(decode_32(
+        &stanza.ephemeral_public_key,
+        "ephemeral_public_key",
+    )?);
+    let shared = identity.encryption_secret()?.diffie_hellman(&ephemeral);
+    let wrap_key = derive_wrap_key(shared.as_bytes(), package_id);
+    let nonce = decode_24(&stanza.nonce, "recipient nonce")?;
+    let wrapped = hex::decode(&stanza.wrapped_key)?;
+    let key = decrypt(&wrap_key, &nonce, package_id.as_bytes(), &wrapped)?;
+    if key.len() != 32 {
+        return Err("unwrapped content key has wrong length".into());
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&key);
+    Ok(out)
+}
+
+fn encrypt(key: &[u8; 32], nonce: &[u8; 24], aad: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {
+    let cipher = XChaCha20Poly1305::new(Key::from_slice(key));
+    cipher
+        .encrypt(
+            XNonce::from_slice(nonce),
+            Payload {
+                msg: plaintext,
+                aad,
+            },
+        )
+        .map_err(|_| "encryption failed".into())
+}
+
+fn decrypt(key: &[u8; 32], nonce: &[u8; 24], aad: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>> {
+    let cipher = XChaCha20Poly1305::new(Key::from_slice(key));
+    cipher
+        .decrypt(
+            XNonce::from_slice(nonce),
+            Payload {
+                msg: ciphertext,
+                aad,
+            },
+        )
+        .map_err(|_| "decryption failed".into())
+}
+
+fn derive_wrap_key(shared: &[u8; 32], package_id: &str) -> [u8; 32] {
+    let mut h = blake3::Hasher::new();
+    h.update(b"qcap-wrap-key-v1");
+    h.update(shared);
+    h.update(package_id.as_bytes());
+    *h.finalize().as_bytes()
+}
+
+fn read_manifest(zip: &mut ZipArchive<fs::File>) -> Result<QcapManifest> {
+    let mut mf = zip.by_name("manifest.json")?;
+    let mut bytes = Vec::new();
+    mf.read_to_end(&mut bytes)?;
+    Ok(QcapManifest::from_json_bytes(&bytes)?)
+}
+
+fn read_signature(zip: &mut ZipArchive<fs::File>) -> Result<QcapSignatureBundle> {
+    let mut sf = zip.by_name("signatures/manifest.sig.json")?;
+    let mut s = String::new();
+    sf.read_to_string(&mut s)?;
+    Ok(serde_json::from_str(&s)?)
+}
+
+fn signing_key_from_seed_file(path: &Path) -> Result<SigningKey> {
+    let key_hex = fs::read_to_string(path)?;
+    Ok(SigningKey::from_bytes(&decode_32(key_hex.trim(), "seed")?))
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T> {
+    Ok(serde_json::from_slice(&fs::read(path)?)?)
+}
+
+fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, serde_json::to_vec_pretty(value)?)?;
+    Ok(())
+}
+
+fn decode_32(value: &str, label: &str) -> Result<[u8; 32]> {
+    let bytes = hex::decode(value)?;
+    if bytes.len() != 32 {
+        return Err(format!("{label} must be 32 bytes").into());
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Ok(out)
+}
+
+fn decode_24(value: &str, label: &str) -> Result<[u8; 24]> {
+    let bytes = hex::decode(value)?;
+    if bytes.len() != 24 {
+        return Err(format!("{label} must be 24 bytes").into());
+    }
+    let mut out = [0u8; 24];
+    out.copy_from_slice(&bytes);
+    Ok(out)
+}
+
+fn walk_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    for entry in WalkDir::new(root).into_iter().filter_map(|e| e.ok()) {
+        if entry.file_type().is_file() {
+            out.push(entry.path().to_path_buf());
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+fn rel_path(root: &Path, abs: &Path) -> Result<String> {
+    let rel = abs.strip_prefix(root)?;
+    let s = rel
+        .to_str()
+        .ok_or("payload path is not valid UTF-8")?
+        .replace('\\', "/");
+    validate_relative_path(&s)?;
+    Ok(s)
+}
+
+fn write_safe(root: &Path, rel: &str, bytes: &[u8]) -> Result<()> {
+    validate_relative_path(rel)?;
+    let dest = root.join(rel);
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(dest, bytes)?;
+    Ok(())
+}
+
+fn validate_relative_path(rel: &str) -> Result<()> {
+    let path = Path::new(rel);
+    if path.is_absolute() || rel.is_empty() {
+        return Err(format!("unsafe payload path: {rel}").into());
+    }
+    for component in path.components() {
+        if matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        ) {
+            return Err(format!("unsafe payload path: {rel}").into());
+        }
+    }
+    Ok(())
+}
+
+fn blake3_prefixed(bytes: &[u8]) -> String {
+    format!("blake3:{}", blake3::hash(bytes).to_hex())
+}
+
+fn random_id() -> String {
+    let mut bytes = [0u8; 16];
+    OsRng.fill_bytes(&mut bytes);
+    format!("qcap_{}", hex::encode(bytes))
+}
+
+fn enforce_expiry(expires: &str) -> Result<()> {
+    if let Some(raw) = expires.strip_prefix("unix-seconds:") {
+        let expiry: u64 = raw.parse()?;
+        let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+        if now > expiry {
+            return Err("capability has expired".into());
+        }
+        return Ok(());
+    }
+    Err("unsupported expiry format; use unix-seconds:<ts>".into())
+}
+
+fn glob_match(pattern: &str, candidate: &str) -> bool {
+    if pattern == "*" || pattern == candidate {
+        return true;
+    }
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        return candidate.starts_with(prefix);
+    }
+    if let Some(suffix) = pattern.strip_prefix('*') {
+        return candidate.ends_with(suffix);
+    }
+    false
 }

--- a/core/qcap-cli/src/main.rs
+++ b/core/qcap-cli/src/main.rs
@@ -6,7 +6,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use chacha20poly1305::aead::{Aead, KeyInit, Payload};
 use chacha20poly1305::{Key, XChaCha20Poly1305, XNonce};
 use clap::{Parser, Subcommand};
-use ed25519_dalek::SigningKey;
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use qcap_core::archive::create_qcap_archive_with_signature;
 use qcap_core::capabilities::CapabilityToken;
 use qcap_core::manifest::{PayloadFile, QcapManifest, RecipientStanza};
@@ -86,14 +86,29 @@ enum Commands {
         cap: PathBuf,
         #[arg(long = "identity")]
         identity: PathBuf,
+        #[arg(long = "revocations")]
+        revocations: Option<PathBuf>,
         #[arg(short = 'o', long = "out")]
         out: PathBuf,
+    },
+    /// Revoke a capability token by adding it to a signed revocation list
+    Revoke {
+        #[arg(long = "cap")]
+        cap: PathBuf,
+        #[arg(long = "issuer")]
+        issuer: PathBuf,
+        #[arg(short = 'o', long = "out")]
+        out: PathBuf,
+        #[arg(long = "reason", default_value = "revoked")]
+        reason: String,
     },
     /// Publish a .qcap to a registry
     Publish {
         file: PathBuf,
         #[arg(long = "registry", default_value = "http://127.0.0.1:8080")]
         registry: String,
+        #[arg(long = "token", env = "QCAP_REGISTRY_TOKEN")]
+        token: Option<String>,
     },
     /// Fetch a .qcap from a registry
     Fetch {
@@ -176,9 +191,20 @@ fn run() -> Result<()> {
             file,
             cap,
             identity,
+            revocations,
             out,
-        } => open_archive(&file, &cap, &identity, &out)?,
-        Commands::Publish { file, registry } => publish(&file, &registry)?,
+        } => open_archive(&file, &cap, &identity, revocations.as_deref(), &out)?,
+        Commands::Revoke {
+            cap,
+            issuer,
+            out,
+            reason,
+        } => revoke(&cap, &issuer, &out, &reason)?,
+        Commands::Publish {
+            file,
+            registry,
+            token,
+        } => publish(&file, &registry, token.as_deref())?,
         Commands::Fetch {
             artifact,
             out,
@@ -241,6 +267,23 @@ impl VerifyReport {
     fn signer_short(&self) -> String {
         self.signature.public_key.chars().take(16).collect()
     }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct RevocationList {
+    schema_version: String,
+    revoked: Vec<RevocationEntry>,
+    signature: String,
+    public_key: String,
+    algorithm: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+struct RevocationEntry {
+    cap_root: String,
+    capability_signature: String,
+    revoked_at: String,
+    reason: String,
 }
 
 fn pack_plain(input_dir: &Path, out: &Path, key: &Path) -> Result<()> {
@@ -349,11 +392,63 @@ fn grant(
     Ok(())
 }
 
-fn open_archive(file: &Path, cap_path: &Path, identity_path: &Path, out: &Path) -> Result<()> {
+fn revoke(cap_path: &Path, issuer_path: &Path, out: &Path, reason: &str) -> Result<()> {
+    let cap: CapabilityToken = read_json(cap_path)?;
+    cap.verify()?;
+    let issuer: Identity = read_json(issuer_path)?;
+    let signing_key = issuer.signing_key()?;
+
+    let mut list = if out.exists() {
+        let list: RevocationList = read_json(out)?;
+        list.verify()?;
+        list
+    } else {
+        RevocationList::empty(&signing_key)
+    };
+
+    let entry = RevocationEntry {
+        cap_root: cap.cap_root.clone(),
+        capability_signature: cap.signature.clone(),
+        revoked_at: unix_timestamp(),
+        reason: reason.to_string(),
+    };
+
+    if !list
+        .revoked
+        .iter()
+        .any(|existing| existing.capability_signature == entry.capability_signature)
+    {
+        list.revoked.push(entry);
+    }
+    list.sign(&signing_key);
+    write_json(out, &list)?;
+    println!(
+        "Revoked capability\n- cap_root: {}\n- revocations: {}\n- out: {}",
+        cap.cap_root,
+        list.revoked.len(),
+        out.display()
+    );
+    Ok(())
+}
+
+fn open_archive(
+    file: &Path,
+    cap_path: &Path,
+    identity_path: &Path,
+    revocations_path: Option<&Path>,
+    out: &Path,
+) -> Result<()> {
     let report = verify_archive(file)?;
     let identity: Identity = read_json(identity_path)?;
     let cap: CapabilityToken = read_json(cap_path)?;
     cap.verify()?;
+    if let Some(path) = revocations_path {
+        let revocations: RevocationList = read_json(path)?;
+        revocations.verify()?;
+        if revocations.revokes(&cap) {
+            return Err("capability has been revoked".into());
+        }
+    }
 
     let access = Access::parse(&cap.allow)?;
     if cap.cap_root != report.manifest.merkle_root {
@@ -500,18 +595,20 @@ fn inspect(file: &Path) -> Result<()> {
     Ok(())
 }
 
-fn publish(file: &Path, registry: &str) -> Result<()> {
+fn publish(file: &Path, registry: &str, token: Option<&str>) -> Result<()> {
     let url = format!("{}/artifacts", registry.trim_end_matches('/'));
     let bytes = fs::read(file)?;
     let name = file
         .file_name()
         .and_then(|n| n.to_str())
         .ok_or("artifact path has no UTF-8 file name")?;
-    let response: PublishResponse = ureq::post(&url)
+    let mut request = ureq::post(&url)
         .set("Content-Type", "application/qcap+zip")
-        .set("X-Qcap-Name", name)
-        .send_bytes(&bytes)?
-        .into_json()?;
+        .set("X-Qcap-Name", name);
+    if let Some(token) = token.filter(|value| !value.is_empty()) {
+        request = request.set("Authorization", &format!("Bearer {token}"));
+    }
+    let response: PublishResponse = request.send_bytes(&bytes)?.into_json()?;
     println!(
         "Published\n- artifact: {}\n- url: {}{}",
         response.name,
@@ -903,6 +1000,74 @@ fn enforce_expiry(expires: &str) -> Result<()> {
         return Ok(());
     }
     Err("unsupported expiry format; use unix-seconds:<ts>".into())
+}
+
+impl RevocationList {
+    fn empty(key: &SigningKey) -> Self {
+        let mut list = Self {
+            schema_version: "0.1.0".to_string(),
+            revoked: Vec::new(),
+            signature: String::new(),
+            public_key: hex::encode(key.verifying_key().to_bytes()),
+            algorithm: "ed25519".to_string(),
+        };
+        list.sign(key);
+        list
+    }
+
+    fn sign(&mut self, key: &SigningKey) {
+        self.public_key = hex::encode(key.verifying_key().to_bytes());
+        self.algorithm = "ed25519".to_string();
+        let sig: Signature = key.sign(self.signing_payload().as_bytes());
+        self.signature = hex::encode(sig.to_bytes());
+    }
+
+    fn verify(&self) -> Result<()> {
+        if self.algorithm != "ed25519" {
+            return Err("unsupported revocation list algorithm".into());
+        }
+        let pk_bytes = hex::decode(&self.public_key)?;
+        let sig_bytes = hex::decode(&self.signature)?;
+        let pk = VerifyingKey::from_bytes(
+            pk_bytes
+                .as_slice()
+                .try_into()
+                .map_err(|_| "bad revocation public key")?,
+        )?;
+        let sig = Signature::from_bytes(
+            sig_bytes
+                .as_slice()
+                .try_into()
+                .map_err(|_| "bad revocation signature")?,
+        );
+        pk.verify(self.signing_payload().as_bytes(), &sig)
+            .map_err(|_| "revocation list signature verify failed".into())
+    }
+
+    fn revokes(&self, cap: &CapabilityToken) -> bool {
+        self.revoked.iter().any(|entry| {
+            entry.capability_signature == cap.signature && entry.cap_root == cap.cap_root
+        })
+    }
+
+    fn signing_payload(&self) -> String {
+        let mut lines = vec![format!("schema_version={}", self.schema_version)];
+        for entry in &self.revoked {
+            lines.push(format!(
+                "{}|{}|{}|{}",
+                entry.cap_root, entry.capability_signature, entry.revoked_at, entry.reason
+            ));
+        }
+        lines.join("\n")
+    }
+}
+
+fn unix_timestamp() -> String {
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    format!("unix-seconds:{seconds}")
 }
 
 fn glob_match(pattern: &str, candidate: &str) -> bool {

--- a/core/qcap-cli/tests/integration.rs
+++ b/core/qcap-cli/tests/integration.rs
@@ -42,10 +42,17 @@ fn pack_then_verify_ok() {
     assert!(out.exists(), "qcap created");
 
     // Verify
-    Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
+    let verify = Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
         .args(["verify", out.to_str().unwrap()])
         .assert()
-        .success();
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert!(
+        String::from_utf8_lossy(&verify).contains("Verification: OK"),
+        "verify reports success"
+    );
 }
 
 #[test]
@@ -226,6 +233,99 @@ fn grant_and_open_flow() {
         .success();
     assert!(export_dir.join("a.txt").exists());
     assert!(export_dir.join("b.bin").exists());
+}
+
+#[test]
+fn revoked_capability_blocks_open() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let payload = root.join("payload");
+    fs::create_dir_all(&payload).unwrap();
+    fs::write(payload.join("a.txt"), b"hello").unwrap();
+
+    let out_qcap = root.join("demo.qcap");
+    let seed = root.join("seed.hex");
+    let cap = root.join("cap.json");
+    let revocations = root.join("revocations.json");
+    let identity = root.join("recipient.identity.json");
+    let export_dir = root.join("exported");
+    write_seed_hex(&seed);
+
+    Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
+        .args([
+            "init",
+            "--name",
+            "recipient",
+            "--out",
+            identity.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let identity_json: serde_json::Value =
+        serde_json::from_slice(&fs::read(&identity).unwrap()).unwrap();
+    let audience = identity_json["signing_public_key"].as_str().unwrap()[0..16].to_string();
+
+    Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
+        .args([
+            "pack",
+            payload.to_str().unwrap(),
+            "--out",
+            out_qcap.to_str().unwrap(),
+            "--key",
+            seed.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
+        .args([
+            "grant",
+            out_qcap.to_str().unwrap(),
+            "--allow",
+            "read",
+            "--audience",
+            &audience,
+            "--expires",
+            "unix-seconds:9999999999",
+            "--issuer",
+            identity.to_str().unwrap(),
+            "--out",
+            cap.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
+        .args([
+            "revoke",
+            "--cap",
+            cap.to_str().unwrap(),
+            "--issuer",
+            identity.to_str().unwrap(),
+            "--out",
+            revocations.to_str().unwrap(),
+            "--reason",
+            "rotation",
+        ])
+        .assert()
+        .success();
+    assert!(revocations.exists(), "revocation list created");
+
+    Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
+        .args([
+            "open",
+            out_qcap.to_str().unwrap(),
+            "--cap",
+            cap.to_str().unwrap(),
+            "--identity",
+            identity.to_str().unwrap(),
+            "--revocations",
+            revocations.to_str().unwrap(),
+            "--out",
+            export_dir.to_str().unwrap(),
+        ])
+        .assert()
+        .failure();
 }
 
 #[test]

--- a/core/qcap-cli/tests/integration.rs
+++ b/core/qcap-cli/tests/integration.rs
@@ -243,6 +243,7 @@ fn seal_grant_open_exports_only_allowed_paths() {
     let qcap = root.join("sealed.qcap");
     let cap = root.join("cap.json");
     let export_dir = root.join("exported");
+    let geopackage = payload.join("reports/observations.gpkg");
 
     Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
         .args([
@@ -264,6 +265,17 @@ fn seal_grant_open_exports_only_allowed_paths() {
         ])
         .assert()
         .success();
+
+    Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
+        .args(["sample-geopackage", "--out", geopackage.to_str().unwrap()])
+        .assert()
+        .success();
+    assert!(
+        fs::read(&geopackage)
+            .unwrap()
+            .starts_with(b"SQLite format 3\0"),
+        "sample GeoPackage is a SQLite database"
+    );
 
     let recipient_json: serde_json::Value =
         serde_json::from_slice(&fs::read(&recipient).unwrap()).unwrap();
@@ -314,5 +326,10 @@ fn seal_grant_open_exports_only_allowed_paths() {
         .success();
 
     assert!(export_dir.join("reports/summary.txt").exists());
+    assert_eq!(
+        fs::read(&geopackage).unwrap(),
+        fs::read(export_dir.join("reports/observations.gpkg")).unwrap(),
+        "GeoPackage should export byte-for-byte unchanged"
+    );
     assert!(!export_dir.join("secrets/private.txt").exists());
 }

--- a/core/qcap-cli/tests/integration.rs
+++ b/core/qcap-cli/tests/integration.rs
@@ -1,12 +1,16 @@
+use assert_cmd::Command;
 use std::fs;
 use std::path::PathBuf;
-use assert_cmd::Command;
 use tempfile::tempdir;
 use zip::ZipArchive;
 
 fn write_seed_hex(path: &PathBuf) {
     // Deterministic 32-byte seed for reproducible tests
-    fs::write(path, "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f").unwrap();
+    fs::write(
+        path,
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+    )
+    .unwrap();
 }
 
 #[test]
@@ -24,7 +28,14 @@ fn pack_then_verify_ok() {
 
     // Pack
     Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
-        .args(["pack", payload.to_str().unwrap(), "--out", out.to_str().unwrap(), "--key", seed.to_str().unwrap()])
+        .args([
+            "pack",
+            payload.to_str().unwrap(),
+            "--out",
+            out.to_str().unwrap(),
+            "--key",
+            seed.to_str().unwrap(),
+        ])
         .assert()
         .success();
 
@@ -52,13 +63,24 @@ fn verify_fails_on_tamper() {
 
     // Pack
     Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
-        .args(["pack", payload.to_str().unwrap(), "--out", out.to_str().unwrap(), "--key", seed.to_str().unwrap()])
+        .args([
+            "pack",
+            payload.to_str().unwrap(),
+            "--out",
+            out.to_str().unwrap(),
+            "--key",
+            seed.to_str().unwrap(),
+        ])
         .assert()
         .success();
 
     // Tamper: rewrite payload/a.txt within the zip
     {
-        let f = fs::OpenOptions::new().read(true).write(true).open(&out).unwrap();
+        let f = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&out)
+            .unwrap();
         let mut zip = ZipArchive::new(f).unwrap();
         {
             let mut file = zip.by_name("payload/a.txt").unwrap();
@@ -84,7 +106,9 @@ fn verify_fails_on_tamper() {
             if entry.is_dir() {
                 fs::create_dir_all(&dest).ok();
             } else {
-                if let Some(parent) = dest.parent() { fs::create_dir_all(parent).ok(); }
+                if let Some(parent) = dest.parent() {
+                    fs::create_dir_all(parent).ok();
+                }
                 let mut buf = Vec::new();
                 use std::io::Read;
                 entry.read_to_end(&mut buf).unwrap();
@@ -96,8 +120,12 @@ fn verify_fails_on_tamper() {
         // Repack minimal: rebuild zip from extracted tree
         let file = fs::File::create(&tampered).unwrap();
         let mut zw = zip::ZipWriter::new(file);
-        let opts = zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
-        for entry in walkdir::WalkDir::new(&extract_dir).into_iter().filter_map(|e| e.ok()) {
+        let opts =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        for entry in walkdir::WalkDir::new(&extract_dir)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
             let p = entry.path();
             let rel = p.strip_prefix(&extract_dir).unwrap();
             let name = rel.to_str().unwrap().replace('\\', "/");
@@ -131,27 +159,160 @@ fn grant_and_open_flow() {
     let out_qcap = root.join("demo.qcap");
     let seed = root.join("seed.hex");
     let cap = root.join("cap.json");
+    let identity = root.join("recipient.identity.json");
     let export_dir = root.join("exported");
     write_seed_hex(&seed);
 
+    Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
+        .args([
+            "init",
+            "--name",
+            "recipient",
+            "--out",
+            identity.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let identity_json: serde_json::Value =
+        serde_json::from_slice(&fs::read(&identity).unwrap()).unwrap();
+    let audience = identity_json["signing_public_key"].as_str().unwrap()[0..16].to_string();
+
     // Pack
     Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
-        .args(["pack", payload.to_str().unwrap(), "--out", out_qcap.to_str().unwrap(), "--key", seed.to_str().unwrap()])
+        .args([
+            "pack",
+            payload.to_str().unwrap(),
+            "--out",
+            out_qcap.to_str().unwrap(),
+            "--key",
+            seed.to_str().unwrap(),
+        ])
         .assert()
         .success();
 
     // Grant
     Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
-        .args(["grant", out_qcap.to_str().unwrap(), "--allow", "read", "--expires", "unix-seconds:9999999999", "--key", seed.to_str().unwrap(), "--out", cap.to_str().unwrap()])
+        .args([
+            "grant",
+            out_qcap.to_str().unwrap(),
+            "--allow",
+            "read",
+            "--audience",
+            &audience,
+            "--expires",
+            "unix-seconds:9999999999",
+            "--issuer",
+            identity.to_str().unwrap(),
+            "--out",
+            cap.to_str().unwrap(),
+        ])
         .assert()
         .success();
     assert!(cap.exists(), "cap token created");
 
     // Open
     Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
-        .args(["open", out_qcap.to_str().unwrap(), "--cap", cap.to_str().unwrap(), "--out", export_dir.to_str().unwrap()])
+        .args([
+            "open",
+            out_qcap.to_str().unwrap(),
+            "--cap",
+            cap.to_str().unwrap(),
+            "--identity",
+            identity.to_str().unwrap(),
+            "--out",
+            export_dir.to_str().unwrap(),
+        ])
         .assert()
         .success();
     assert!(export_dir.join("a.txt").exists());
     assert!(export_dir.join("b.bin").exists());
+}
+
+#[test]
+fn seal_grant_open_exports_only_allowed_paths() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let payload = root.join("payload");
+    fs::create_dir_all(payload.join("reports")).unwrap();
+    fs::create_dir_all(payload.join("secrets")).unwrap();
+    fs::write(payload.join("reports/summary.txt"), b"allowed").unwrap();
+    fs::write(payload.join("secrets/private.txt"), b"blocked").unwrap();
+
+    let issuer = root.join("issuer.identity.json");
+    let recipient = root.join("recipient.identity.json");
+    let qcap = root.join("sealed.qcap");
+    let cap = root.join("cap.json");
+    let export_dir = root.join("exported");
+
+    Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
+        .args([
+            "init",
+            "--name",
+            "issuer",
+            "--out",
+            issuer.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
+        .args([
+            "init",
+            "--name",
+            "recipient",
+            "--out",
+            recipient.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let recipient_json: serde_json::Value =
+        serde_json::from_slice(&fs::read(&recipient).unwrap()).unwrap();
+    let audience = recipient_json["signing_public_key"].as_str().unwrap()[0..16].to_string();
+
+    Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
+        .args([
+            "seal",
+            payload.to_str().unwrap(),
+            "--issuer",
+            issuer.to_str().unwrap(),
+            "--recipient",
+            recipient.to_str().unwrap(),
+            "--out",
+            qcap.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
+        .args([
+            "grant",
+            qcap.to_str().unwrap(),
+            "--issuer",
+            issuer.to_str().unwrap(),
+            "--audience",
+            &audience,
+            "--path",
+            "reports/*",
+            "--out",
+            cap.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    Command::new(assert_cmd::cargo::cargo_bin!("qcap-cli"))
+        .args([
+            "open",
+            qcap.to_str().unwrap(),
+            "--cap",
+            cap.to_str().unwrap(),
+            "--identity",
+            recipient.to_str().unwrap(),
+            "--out",
+            export_dir.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(export_dir.join("reports/summary.txt").exists());
+    assert!(!export_dir.join("secrets/private.txt").exists());
 }

--- a/core/qcap-core/Cargo.toml
+++ b/core/qcap-core/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 blake3 = "1"
 chacha20poly1305 = "0.10"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
+rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
@@ -16,3 +17,4 @@ walkdir = "2"
 tempfile = "3"
 hex = "0.4"
 rand_core = "0.6"
+x25519-dalek = { version = "2", features = ["static_secrets"] }

--- a/core/qcap-core/src/archive.rs
+++ b/core/qcap-core/src/archive.rs
@@ -14,7 +14,11 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>
 /// - `payload/…` (all files under input_dir)
 /// - `meta/` (empty)
 /// - `signatures/` (empty)
-pub fn create_qcap_archive(input_dir: &Path, manifest: &QcapManifest, output_file: &Path) -> Result<()> {
+pub fn create_qcap_archive(
+    input_dir: &Path,
+    manifest: &QcapManifest,
+    output_file: &Path,
+) -> Result<()> {
     // Ensure input_dir exists
     if !input_dir.is_dir() {
         return Err(format!("input_dir is not a directory: {}", input_dir.display()).into());
@@ -90,7 +94,10 @@ pub fn create_qcap_archive_with_signature(
 
 fn walk_files(root: &Path) -> Result<Vec<PathBuf>> {
     let mut out = Vec::new();
-    for entry in walkdir::WalkDir::new(root).into_iter().filter_map(|e| e.ok()) {
+    for entry in walkdir::WalkDir::new(root)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
         let p = entry.path();
         if p.is_file() {
             out.push(p.to_path_buf());
@@ -111,8 +118,8 @@ fn path_to_string(p: &Path) -> Result<String> {
 mod tests {
     use super::*;
     use crate::manifest::QcapManifest;
-    use std::io::Read;
     use std::fs;
+    use std::io::Read;
     use tempfile::tempdir;
     use zip::read::ZipArchive;
 
@@ -151,11 +158,17 @@ mod tests {
         // meta/ and signatures/ directories exist (they may not be listed as entries depending on zip impl,
         // but we can try to access them by name; if not, ensure payload files exist)
         let mut file1 = String::new();
-        zip.by_name("payload/file1.txt").unwrap().read_to_string(&mut file1).unwrap();
+        zip.by_name("payload/file1.txt")
+            .unwrap()
+            .read_to_string(&mut file1)
+            .unwrap();
         assert_eq!(file1, "hello");
 
         let mut file2 = Vec::new();
-        zip.by_name("payload/file2.bin").unwrap().read_to_end(&mut file2).unwrap();
+        zip.by_name("payload/file2.bin")
+            .unwrap()
+            .read_to_end(&mut file2)
+            .unwrap();
         assert_eq!(file2, vec![1u8, 2, 3, 4]);
     }
 }

--- a/core/qcap-core/src/capabilities.rs
+++ b/core/qcap-core/src/capabilities.rs
@@ -1,4 +1,4 @@
-use ed25519_dalek::{Signer, Verifier, Signature, SigningKey, VerifyingKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
@@ -29,7 +29,9 @@ impl CapabilityToken {
     }
 
     pub fn verify(&self) -> Result<()> {
-        if self.algorithm != "ed25519" { return Err("unsupported algorithm".into()); }
+        if self.algorithm != "ed25519" {
+            return Err("unsupported algorithm".into());
+        }
         let pk_bytes = hex::decode(&self.public_key)?;
         let sig_bytes = hex::decode(&self.signature)?;
         let pk = VerifyingKey::from_bytes(pk_bytes.as_slice().try_into().map_err(|_| "bad pk")?)?;

--- a/core/qcap-core/src/lib.rs
+++ b/core/qcap-core/src/lib.rs
@@ -2,11 +2,11 @@
 use blake3::Hasher;
 use thiserror::Error;
 
-pub mod manifest;
 pub mod archive;
+pub mod capabilities;
+pub mod manifest;
 pub mod payload_merkle;
 pub mod signatures;
-pub mod capabilities;
 
 #[derive(Debug, Error)]
 pub enum QcapError {

--- a/core/qcap-core/src/manifest.rs
+++ b/core/qcap-core/src/manifest.rs
@@ -5,11 +5,38 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// Minimal manifest for the MVP.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct QcapManifest {
-    pub schema_version: String,      // e.g. "0.1.0"
-    pub merkle_root: String,         // "blake3:<hex>"
-    pub issuer: Option<String>,      // key fingerprint or issuer id
-    pub created_at: String,          // RFC3339
-    pub metadata: Value,             // free-form (title, description, tags, etc.)
+    pub schema_version: String, // e.g. "0.1.0"
+    pub merkle_root: String,    // "blake3:<hex>"
+    pub issuer: Option<String>, // key fingerprint or issuer id
+    pub created_at: String,     // RFC3339
+    pub metadata: Value,        // free-form (title, description, tags, etc.)
+    #[serde(default)]
+    pub package_id: Option<String>,
+    #[serde(default)]
+    pub encrypted: bool,
+    #[serde(default)]
+    pub files: Vec<PayloadFile>,
+    #[serde(default)]
+    pub recipients: Vec<RecipientStanza>,
+    #[serde(default)]
+    pub algorithms: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct PayloadFile {
+    pub path: String,
+    pub size: u64,
+    pub nonce: String,
+    pub ciphertext_hash: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct RecipientStanza {
+    pub recipient: String,
+    pub ephemeral_public_key: String,
+    pub nonce: String,
+    pub wrapped_key: String,
+    pub algorithm: String,
 }
 
 impl QcapManifest {
@@ -27,6 +54,38 @@ impl QcapManifest {
             issuer,
             created_at: created_at.into(),
             metadata,
+            package_id: None,
+            encrypted: false,
+            files: Vec::new(),
+            recipients: Vec::new(),
+            algorithms: Vec::new(),
+        }
+    }
+
+    pub fn new_sealed(
+        schema_version: impl Into<String>,
+        package_id: impl Into<String>,
+        merkle_root: impl Into<String>,
+        issuer: Option<String>,
+        metadata: Value,
+        files: Vec<PayloadFile>,
+        recipients: Vec<RecipientStanza>,
+    ) -> Self {
+        Self {
+            schema_version: schema_version.into(),
+            package_id: Some(package_id.into()),
+            merkle_root: merkle_root.into(),
+            issuer,
+            created_at: rfc3339_now(),
+            metadata,
+            encrypted: true,
+            files,
+            recipients,
+            algorithms: vec![
+                "xchacha20poly1305:file".to_string(),
+                "x25519-blake3-xchacha20poly1305:keywrap".to_string(),
+                "ed25519:signature".to_string(),
+            ],
         }
     }
 
@@ -55,7 +114,9 @@ impl QcapManifest {
 fn rfc3339_now() -> String {
     // Use chrono if added later; for now, synthesize from SystemTime as an ISO-like string.
     // Fallback to unix timestamp seconds to avoid extra deps.
-    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
     // Represent as seconds since epoch; acceptable for MVP, though not strict RFC3339.
     // Example: "unix-seconds:1733420000"
     format!("unix-seconds:{}", now.as_secs())

--- a/core/qcap-core/src/payload_merkle.rs
+++ b/core/qcap-core/src/payload_merkle.rs
@@ -1,6 +1,6 @@
 use blake3::Hasher;
 use std::fs::File;
-use std::io::{Read};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
@@ -15,10 +15,14 @@ pub fn compute_payload_merkle_root(input_dir: &Path) -> Result<String> {
     let mut leaves: Vec<[u8; 32]> = Vec::new();
     for abs in files {
         let rel = abs.strip_prefix(input_dir).unwrap();
-        let path_bytes = rel.as_os_str().to_string_lossy().replace('\\', "/").into_bytes();
-    let mut h = Hasher::new();
-    h.update(&path_bytes);
-    h.update(&[0]);
+        let path_bytes = rel
+            .as_os_str()
+            .to_string_lossy()
+            .replace('\\', "/")
+            .into_bytes();
+        let mut h = Hasher::new();
+        h.update(&path_bytes);
+        h.update(&[0]);
         let mut f = File::open(&abs)?;
         let mut buf = Vec::new();
         f.read_to_end(&mut buf)?;
@@ -28,7 +32,7 @@ pub fn compute_payload_merkle_root(input_dir: &Path) -> Result<String> {
 
     if leaves.is_empty() {
         // empty directory -> hash of empty string
-        let mut h = Hasher::new();
+        let h = Hasher::new();
         let root = h.finalize();
         return Ok(format!("blake3:{}", root.to_hex()));
     }
@@ -53,12 +57,18 @@ pub fn compute_payload_merkle_root(input_dir: &Path) -> Result<String> {
         }
         level = next;
     }
-    Ok(format!("blake3:{}", blake3::Hash::from_bytes(level[0]).to_hex()))
+    Ok(format!(
+        "blake3:{}",
+        blake3::Hash::from_bytes(level[0]).to_hex()
+    ))
 }
 
 fn list_files(root: &Path) -> Result<Vec<PathBuf>> {
     let mut out = Vec::new();
-    for entry in walkdir::WalkDir::new(root).into_iter().filter_map(|e| e.ok()) {
+    for entry in walkdir::WalkDir::new(root)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
         let p = entry.path();
         if p.is_file() {
             out.push(p.to_path_buf());

--- a/core/qcap-core/src/signatures.rs
+++ b/core/qcap-core/src/signatures.rs
@@ -1,4 +1,4 @@
-use ed25519_dalek::{Signer, Verifier, Signature, SigningKey, VerifyingKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
@@ -6,9 +6,9 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct QcapSignatureBundle {
     pub merkle_root: String,
-    pub signature: String,   // hex
-    pub public_key: String,  // hex (32 bytes)
-    pub algorithm: String,   // "ed25519"
+    pub signature: String,  // hex
+    pub public_key: String, // hex (32 bytes)
+    pub algorithm: String,  // "ed25519"
 }
 
 pub fn sign_merkle_root(root: &str, keypair: &SigningKey) -> QcapSignatureBundle {

--- a/scripts/demo.ps1
+++ b/scripts/demo.ps1
@@ -10,6 +10,7 @@ $DemoQcap = Join-Path $Work "demo.qcap"
 $Cap = Join-Path $Work "cap.json"
 $Issuer = Join-Path $Work "issuer.identity.json"
 $Recipient = Join-Path $Work "recipient.identity.json"
+$GeoPackage = Join-Path $Payload "reports\observations.gpkg"
 $RegistryOut = Join-Path $Work "registry.out.log"
 $RegistryErr = Join-Path $Work "registry.err.log"
 $RegistryExe = Join-Path $Work "qcap-registry.exe"
@@ -66,6 +67,9 @@ try {
   $recipientIdentity = Get-Content -Raw $Recipient | ConvertFrom-Json
   $recipientAudience = $recipientIdentity.signing_public_key.Substring(0, 16)
 
+  Step "creating sample GeoPackage payload"
+  Run $QcapExe @("sample-geopackage", "--out", $GeoPackage)
+
   Step "sealing encrypted .qcap"
   Run $QcapExe @("seal", $Payload, "--issuer", $Issuer, "--recipient", $Recipient, "--out", $DemoQcap)
   Run $QcapExe @("inspect", $DemoQcap)
@@ -96,12 +100,21 @@ try {
   if (!(Test-Path (Join-Path $Exported "reports\summary.txt"))) {
     throw "allowed report was not exported"
   }
+  if (!(Test-Path (Join-Path $Exported "reports\observations.gpkg"))) {
+    throw "sample GeoPackage was not exported"
+  }
+  $originalGeoPackageHash = (Get-FileHash -Algorithm SHA256 $GeoPackage).Hash
+  $exportedGeoPackageHash = (Get-FileHash -Algorithm SHA256 (Join-Path $Exported "reports\observations.gpkg")).Hash
+  if ($originalGeoPackageHash -ne $exportedGeoPackageHash) {
+    throw "sample GeoPackage changed during seal/open"
+  }
   if (Test-Path (Join-Path $Exported "secrets\private.txt")) {
     throw "restricted secret was exported"
   }
 
   Step "MVP demo complete"
   Write-Host "Allowed output: $(Join-Path $Exported "reports\summary.txt")"
+  Write-Host "GeoPackage output: $(Join-Path $Exported "reports\observations.gpkg")"
   Write-Host "Restricted output correctly absent: secrets\private.txt"
 } finally {
   if ($registryProcess -and !$registryProcess.HasExited) {

--- a/scripts/demo.ps1
+++ b/scripts/demo.ps1
@@ -1,0 +1,111 @@
+$ErrorActionPreference = "Stop"
+
+$Root = Resolve-Path (Join-Path $PSScriptRoot "..")
+$Work = Join-Path $Root "target\qcap-demo"
+$RegistryDir = Join-Path $Work "registry"
+$Payload = Join-Path $Work "payload"
+$Exported = Join-Path $Work "exported"
+$Fetched = Join-Path $Work "fetched.qcap"
+$DemoQcap = Join-Path $Work "demo.qcap"
+$Cap = Join-Path $Work "cap.json"
+$Issuer = Join-Path $Work "issuer.identity.json"
+$Recipient = Join-Path $Work "recipient.identity.json"
+$RegistryOut = Join-Path $Work "registry.out.log"
+$RegistryErr = Join-Path $Work "registry.err.log"
+$RegistryExe = Join-Path $Work "qcap-registry.exe"
+$QcapExe = Join-Path $Root "target\debug\qcap-cli.exe"
+
+function Step($Message) {
+  Write-Host "==> $Message"
+}
+
+function Run($FilePath, $Arguments) {
+  & $FilePath @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "$FilePath failed with exit code $LASTEXITCODE"
+  }
+}
+
+function RunExpectFailure($FilePath, $Arguments, $SuccessMessage) {
+  $stdout = [System.IO.Path]::GetTempFileName()
+  $stderr = [System.IO.Path]::GetTempFileName()
+  $process = Start-Process -FilePath $FilePath -ArgumentList $Arguments -NoNewWindow -Wait -PassThru -RedirectStandardOutput $stdout -RedirectStandardError $stderr
+  Remove-Item -Force $stdout, $stderr -ErrorAction SilentlyContinue
+  if ($process.ExitCode -eq 0) {
+    throw "$FilePath unexpectedly succeeded"
+  }
+  Write-Host $SuccessMessage
+}
+
+function StopPort($Port) {
+  $connections = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
+  foreach ($connection in $connections) {
+    Stop-Process -Id $connection.OwningProcess -Force -ErrorAction SilentlyContinue
+  }
+}
+
+StopPort 8080
+
+if (Test-Path $Work) {
+  Remove-Item -Recurse -Force $Work
+}
+New-Item -ItemType Directory -Force $Payload, $RegistryDir | Out-Null
+New-Item -ItemType Directory -Force (Join-Path $Payload "reports"), (Join-Path $Payload "secrets") | Out-Null
+Set-Content -NoNewline -Path (Join-Path $Payload "reports\summary.txt") -Value "Q-Cap MVP: this report is allowed."
+Set-Content -NoNewline -Path (Join-Path $Payload "secrets\private.txt") -Value "This should stay blocked by the capability."
+
+Push-Location $Root
+$registryProcess = $null
+try {
+  Step "building Rust workspace"
+  Run "cargo" @("build", "--workspace", "--quiet")
+
+  Step "creating issuer and recipient identities"
+  Run $QcapExe @("init", "--name", "issuer", "--out", $Issuer)
+  Run $QcapExe @("init", "--name", "recipient", "--out", $Recipient)
+  $recipientIdentity = Get-Content -Raw $Recipient | ConvertFrom-Json
+  $recipientAudience = $recipientIdentity.signing_public_key.Substring(0, 16)
+
+  Step "sealing encrypted .qcap"
+  Run $QcapExe @("seal", $Payload, "--issuer", $Issuer, "--recipient", $Recipient, "--out", $DemoQcap)
+  Run $QcapExe @("inspect", $DemoQcap)
+
+  Step "starting registry"
+  Push-Location (Join-Path $Root "services\qcap-registry")
+  try {
+    Run "go" @("build", "-o", $RegistryExe, ".")
+  } finally {
+    Pop-Location
+  }
+  $env:QCAP_REGISTRY_SEED = $RegistryDir
+  $registryProcess = Start-Process -FilePath $RegistryExe -WorkingDirectory $Root -WindowStyle Hidden -RedirectStandardOutput $RegistryOut -RedirectStandardError $RegistryErr -PassThru
+  Start-Sleep -Seconds 2
+
+  Step "publishing and fetching artifact"
+  Run $QcapExe @("publish", $DemoQcap, "--registry", "http://127.0.0.1:8080")
+  Run $QcapExe @("fetch", "demo.qcap", "--out", $Fetched, "--registry", "http://127.0.0.1:8080")
+
+  Step "proving open fails without a capability"
+  RunExpectFailure $QcapExe @("open", $Fetched, "--cap", (Join-Path $Work "missing-cap.json"), "--identity", $Recipient, "--out", $Exported) "OK blocked open without capability"
+
+  Step "granting capability for reports/* only"
+  Run $QcapExe @("grant", $Fetched, "--issuer", $Issuer, "--audience", $recipientAudience, "--path", "reports/*", "--expires", "unix-seconds:9999999999", "--out", $Cap)
+
+  Step "opening with capability"
+  Run $QcapExe @("open", $Fetched, "--cap", $Cap, "--identity", $Recipient, "--out", $Exported)
+  if (!(Test-Path (Join-Path $Exported "reports\summary.txt"))) {
+    throw "allowed report was not exported"
+  }
+  if (Test-Path (Join-Path $Exported "secrets\private.txt")) {
+    throw "restricted secret was exported"
+  }
+
+  Step "MVP demo complete"
+  Write-Host "Allowed output: $(Join-Path $Exported "reports\summary.txt")"
+  Write-Host "Restricted output correctly absent: secrets\private.txt"
+} finally {
+  if ($registryProcess -and !$registryProcess.HasExited) {
+    Stop-Process -Id $registryProcess.Id -Force
+  }
+  Pop-Location
+}

--- a/scripts/demo.ps1
+++ b/scripts/demo.ps1
@@ -5,9 +5,11 @@ $Work = Join-Path $Root "target\qcap-demo"
 $RegistryDir = Join-Path $Work "registry"
 $Payload = Join-Path $Work "payload"
 $Exported = Join-Path $Work "exported"
+$RevokedExported = Join-Path $Work "revoked-exported"
 $Fetched = Join-Path $Work "fetched.qcap"
 $DemoQcap = Join-Path $Work "demo.qcap"
 $Cap = Join-Path $Work "cap.json"
+$Revocations = Join-Path $Work "revocations.json"
 $Issuer = Join-Path $Work "issuer.identity.json"
 $Recipient = Join-Path $Work "recipient.identity.json"
 $GeoPackage = Join-Path $Payload "reports\observations.gpkg"
@@ -15,6 +17,8 @@ $RegistryOut = Join-Path $Work "registry.out.log"
 $RegistryErr = Join-Path $Work "registry.err.log"
 $RegistryExe = Join-Path $Work "qcap-registry.exe"
 $QcapExe = Join-Path $Root "target\debug\qcap-cli.exe"
+$CargoExe = Join-Path $env:USERPROFILE ".cargo\bin\cargo.exe"
+$GoExe = "C:\Program Files\Go\bin\go.exe"
 
 function Step($Message) {
   Write-Host "==> $Message"
@@ -59,7 +63,7 @@ Push-Location $Root
 $registryProcess = $null
 try {
   Step "building Rust workspace"
-  Run "cargo" @("build", "--workspace", "--quiet")
+  Run $CargoExe @("build", "--workspace", "--quiet")
 
   Step "creating issuer and recipient identities"
   Run $QcapExe @("init", "--name", "issuer", "--out", $Issuer)
@@ -72,22 +76,25 @@ try {
 
   Step "sealing encrypted .qcap"
   Run $QcapExe @("seal", $Payload, "--issuer", $Issuer, "--recipient", $Recipient, "--out", $DemoQcap)
+  Run $QcapExe @("verify", $DemoQcap)
   Run $QcapExe @("inspect", $DemoQcap)
 
   Step "starting registry"
   Push-Location (Join-Path $Root "services\qcap-registry")
   try {
-    Run "go" @("build", "-o", $RegistryExe, ".")
+    Run $GoExe @("build", "-o", $RegistryExe, ".")
   } finally {
     Pop-Location
   }
   $env:QCAP_REGISTRY_SEED = $RegistryDir
+  $env:QCAP_REGISTRY_TOKEN = "demo-token"
   $registryProcess = Start-Process -FilePath $RegistryExe -WorkingDirectory $Root -WindowStyle Hidden -RedirectStandardOutput $RegistryOut -RedirectStandardError $RegistryErr -PassThru
   Start-Sleep -Seconds 2
 
   Step "publishing and fetching artifact"
-  Run $QcapExe @("publish", $DemoQcap, "--registry", "http://127.0.0.1:8080")
+  Run $QcapExe @("publish", $DemoQcap, "--registry", "http://127.0.0.1:8080", "--token", "demo-token")
   Run $QcapExe @("fetch", "demo.qcap", "--out", $Fetched, "--registry", "http://127.0.0.1:8080")
+  Run $QcapExe @("verify", $Fetched)
 
   Step "proving open fails without a capability"
   RunExpectFailure $QcapExe @("open", $Fetched, "--cap", (Join-Path $Work "missing-cap.json"), "--identity", $Recipient, "--out", $Exported) "OK blocked open without capability"
@@ -111,6 +118,10 @@ try {
   if (Test-Path (Join-Path $Exported "secrets\private.txt")) {
     throw "restricted secret was exported"
   }
+
+  Step "revoking capability and proving it is blocked"
+  Run $QcapExe @("revoke", "--cap", $Cap, "--issuer", $Issuer, "--reason", "demo-complete", "--out", $Revocations)
+  RunExpectFailure $QcapExe @("open", $Fetched, "--cap", $Cap, "--identity", $Recipient, "--revocations", $Revocations, "--out", $RevokedExported) "OK blocked revoked capability"
 
   Step "MVP demo complete"
   Write-Host "Allowed output: $(Join-Path $Exported "reports\summary.txt")"

--- a/sdks/ts/package-lock.json
+++ b/sdks/ts/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "@qcap/sdk",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@qcap/sdk",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/sdks/ts/package.json
+++ b/sdks/ts/package.json
@@ -4,5 +4,8 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": { "build": "tsc -p ." },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "typescript": "^5.5.0"
+  }
 }

--- a/services/qcap-registry/README.md
+++ b/services/qcap-registry/README.md
@@ -1,31 +1,36 @@
 # Q-Cap Registry (MVP)
 
-A minimal registry that serves a health check, an index of `.qcap` files scanned from a seed directory, and the `.qcap` artifacts themselves.
+A minimal registry that stores `.qcap` artifacts on disk, persists an `index.json`, and can require bearer-token auth for publishing.
 
 ## Endpoints
 
-- `GET /health` — `{"status":"ok"}`
-- `GET /index.json` — JSON array of capsules `{ name, path, size, content_type }`
-- `GET /artifacts/<name>` — serves the `.qcap` file directly from the seed dir
+- `GET /health` - JSON status, including whether publish auth is enabled
+- `GET /index.json` - JSON array of capsules
+- `GET /index` - HTML index listing
+- `POST /artifacts` - publish a `.qcap`
+- `GET /artifacts/<name>` - download a `.qcap`
 
-## Seed Directory
+## Configuration
 
-By default, the registry scans `services/qcap-registry/seed`. You can override by setting `QCAP_REGISTRY_SEED`.
+- `QCAP_REGISTRY_STORE` - artifact directory
+- `QCAP_REGISTRY_SEED` - backward-compatible alias for `QCAP_REGISTRY_STORE`
+- `QCAP_REGISTRY_INDEX` - index file path, defaults to `<store>/index.json`
+- `QCAP_REGISTRY_TOKEN` - when set, `POST /artifacts` requires `Authorization: Bearer <token>`
 
-## Seed helper (optional)
-
-Seed directory defaults to `services/qcap-registry/seed` or set `QCAP_REGISTRY_SEED`.
-
-Quick start:
+## Quick Start
 
 ```sh
 # Seed with demo capsules
 scripts/seed-registry.sh
 
-# Run registry
-go run services/qcap-registry/main.go
+# Run registry with publish auth
+QCAP_REGISTRY_TOKEN=demo-token go run services/qcap-registry/main.go
 
-# Smoke test endpoints (optional)
+# Publish with the CLI
+cargo run -p qcap-cli -- publish target/qcap-demo/demo.qcap \
+  --registry http://127.0.0.1:8080 \
+  --token demo-token
+
+# Smoke test endpoints
 scripts/smoke-registry.sh
 ```
-cargo run -p qcap-cli -- pack /tmp/qcap-seed-b --out services/qcap-registry/seed/beta.qcap --key /tmp/ed25519.seed.hex

--- a/services/qcap-registry/main.go
+++ b/services/qcap-registry/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -8,7 +10,10 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"sync"
+	"time"
 )
 
 type Capsule struct {
@@ -16,159 +21,280 @@ type Capsule struct {
 	Path        string `json:"path"`
 	Size        int64  `json:"size"`
 	ContentType string `json:"content_type"`
+	Digest      string `json:"digest"`
+	CreatedAt   string `json:"created_at"`
 }
 
 type Registry struct {
-	SeedDir string
-	Index   []Capsule
-}
+	StoreDir  string
+	IndexPath string
+	Token     string
 
-func (r *Registry) loadIndex() error {
-	var idx []Capsule
-	err := filepath.Walk(r.SeedDir, func(p string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			return nil
-		}
-		if filepath.Ext(p) == ".qcap" {
-			name := filepath.Base(p)
-			idx = append(idx, Capsule{
-				Name:        name,
-				Path:        "/artifacts/" + name,
-				Size:        info.Size(),
-				ContentType: "application/qcap+zip",
-			})
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-	r.Index = idx
-	return nil
+	mu    sync.Mutex
+	Index []Capsule
 }
 
 func main() {
-	seedDir := os.Getenv("QCAP_REGISTRY_SEED")
-	if seedDir == "" {
-		seedDir = "services/qcap-registry/seed"
+	storeDir := firstNonEmpty(os.Getenv("QCAP_REGISTRY_STORE"), os.Getenv("QCAP_REGISTRY_SEED"))
+	if storeDir == "" {
+		storeDir = "services/qcap-registry/seed"
 	}
-	reg := &Registry{SeedDir: seedDir}
-	if err := os.MkdirAll(seedDir, 0755); err != nil {
-		log.Fatalf("could not create seed dir: %v", err)
+	indexPath := os.Getenv("QCAP_REGISTRY_INDEX")
+	if indexPath == "" {
+		indexPath = filepath.Join(storeDir, "index.json")
+	}
+
+	reg := &Registry{
+		StoreDir:  storeDir,
+		IndexPath: indexPath,
+		Token:     os.Getenv("QCAP_REGISTRY_TOKEN"),
+	}
+	if err := os.MkdirAll(storeDir, 0755); err != nil {
+		log.Fatalf("could not create registry store: %v", err)
 	}
 	if err := reg.loadIndex(); err != nil {
-		log.Printf("warn: could not load seed: %v", err)
+		log.Printf("warn: could not load index: %v", err)
 	}
 
 	mux := http.NewServeMux()
-
-	// Root landing page
-	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`<!doctype html><html><head><meta charset="utf-8"><title>QCAP Registry</title></head><body>
-							<h1>QCAP Registry (demo)</h1>
-							<p>This is a minimal, read-only registry for demo purposes. It serves a seeded list of <code>.qcap</code> capsules from a local directory. Use the links below to explore.</p>
-				<ul>
-								<li><a href="/health">/health</a> (JSON status)</li>
-								<li><a href="/health.html">/health.html</a> (HTML status)</li>
-								<li><a href="/index.json">/index.json</a> (JSON index)</li>
-								<li><a href="/index">/index</a> (HTML index)</li>
-								<li><a href="/artifacts/">/artifacts/</a> (static downloads)</li>
-				</ul>
-			</body></html>`))
-	})
-
-	// JSON health endpoint
-	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"status":"ok"}`))
-	})
-
-	// HTML health page with description
-	mux.HandleFunc("/health.html", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`<!doctype html><html><head><meta charset="utf-8"><title>Health</title></head><body>
-				<h1>Health</h1>
-				<p>This endpoint reports the registry status. If you see "ok", the server is running.</p>
-				<pre>{"status":"ok"}</pre>
-				<p>For machine-readable output, use <a href="/health">/health</a>.</p>
-			</body></html>`))
-	})
-
-	// JSON index endpoint
-	mux.HandleFunc("/index.json", func(w http.ResponseWriter, _ *http.Request) {
-		_ = reg.loadIndex()
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(reg.Index)
-	})
-
-	// HTML index page with description and simple listing
-	mux.HandleFunc("/index", func(w http.ResponseWriter, _ *http.Request) {
-		_ = reg.loadIndex()
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("<!doctype html><html><head><meta charset=\"utf-8\"><title>Index</title></head><body>"))
-		w.Write([]byte("<h1>Artifact Index</h1>\n"))
-		w.Write([]byte("<p>This page lists the seeded .qcap capsules available for download. Use the links to retrieve artifacts.</p>"))
-		if len(reg.Index) == 0 {
-			w.Write([]byte("<p><em>No artifacts found in seed directory.</em></p>"))
-		} else {
-			w.Write([]byte("<ul>"))
-			for _, c := range reg.Index {
-				w.Write([]byte("<li>"))
-				w.Write([]byte(c.Name))
-				w.Write([]byte(" — <a href=\"" + c.Path + "\">download</a> (" + c.ContentType + ", " + formatSize(c.Size) + ")"))
-				w.Write([]byte("</li>"))
-			}
-			w.Write([]byte("</ul>"))
-		}
-		w.Write([]byte("<p>Machine-readable index: <a href=\"/index.json\">/index.json</a></p>"))
-		w.Write([]byte("</body></html>"))
-	})
-
-	mux.HandleFunc("/artifacts", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		name := safeArtifactName(r.Header.Get("X-Qcap-Name"))
-		if name == "" {
-			name = "artifact.qcap"
-		}
-		if filepath.Ext(name) != ".qcap" {
-			name += ".qcap"
-		}
-		dest := filepath.Join(seedDir, name)
-		out, err := os.Create(dest)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		defer out.Close()
-		if _, err := io.Copy(out, http.MaxBytesReader(w, r.Body, 512<<20)); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		_ = reg.loadIndex()
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(Capsule{
-			Name:        name,
-			Path:        "/artifacts/" + name,
-			ContentType: "application/qcap+zip",
-		})
-	})
-
-	mux.Handle("/artifacts/", http.StripPrefix("/artifacts/", http.FileServer(http.Dir(seedDir))))
+	mux.HandleFunc("/", reg.root)
+	mux.HandleFunc("/health", reg.health)
+	mux.HandleFunc("/health.html", reg.healthHTML)
+	mux.HandleFunc("/index.json", reg.indexJSON)
+	mux.HandleFunc("/index", reg.indexHTML)
+	mux.HandleFunc("/artifacts", reg.publish)
+	mux.HandleFunc("/artifacts/", reg.artifact)
 
 	addr := ":8080"
-	log.Printf("registry listening on %s; seed dir: %s", addr, seedDir)
+	log.Printf("registry listening on %s; store dir: %s; index: %s", addr, storeDir, indexPath)
 	log.Fatal(http.ListenAndServe(addr, mux))
+}
+
+func (r *Registry) loadIndex() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.loadIndexLocked()
+}
+
+func (r *Registry) loadIndexLocked() error {
+	var idx []Capsule
+	if bytes, err := os.ReadFile(r.IndexPath); err == nil && len(bytes) > 0 {
+		if err := json.Unmarshal(bytes, &idx); err != nil {
+			return err
+		}
+	}
+
+	byName := make(map[string]Capsule)
+	for _, capsule := range idx {
+		byName[capsule.Name] = capsule
+	}
+
+	if err := filepath.Walk(r.StoreDir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || filepath.Clean(p) == filepath.Clean(r.IndexPath) {
+			return nil
+		}
+		if filepath.Ext(p) != ".qcap" {
+			return nil
+		}
+		name := filepath.Base(p)
+		existing := byName[name]
+		digest, err := fileDigest(p)
+		if err != nil {
+			return err
+		}
+		createdAt := existing.CreatedAt
+		if createdAt == "" {
+			createdAt = info.ModTime().UTC().Format(time.RFC3339)
+		}
+		byName[name] = Capsule{
+			Name:        name,
+			Path:        "/artifacts/" + name,
+			Size:        info.Size(),
+			ContentType: "application/qcap+zip",
+			Digest:      digest,
+			CreatedAt:   createdAt,
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	r.Index = r.Index[:0]
+	for _, capsule := range byName {
+		r.Index = append(r.Index, capsule)
+	}
+	sort.Slice(r.Index, func(i, j int) bool {
+		return r.Index[i].Name < r.Index[j].Name
+	})
+	return r.saveIndexLocked()
+}
+
+func (r *Registry) saveIndexLocked() error {
+	if err := os.MkdirAll(filepath.Dir(r.IndexPath), 0755); err != nil {
+		return err
+	}
+	bytes, err := json.MarshalIndent(r.Index, "", "  ")
+	if err != nil {
+		return err
+	}
+	bytes = append(bytes, '\n')
+	return os.WriteFile(r.IndexPath, bytes, 0644)
+}
+
+func (r *Registry) upsert(c Capsule) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i := range r.Index {
+		if r.Index[i].Name == c.Name {
+			if r.Index[i].CreatedAt != "" {
+				c.CreatedAt = r.Index[i].CreatedAt
+			}
+			r.Index[i] = c
+			return r.saveIndexLocked()
+		}
+	}
+	r.Index = append(r.Index, c)
+	sort.Slice(r.Index, func(i, j int) bool {
+		return r.Index[i].Name < r.Index[j].Name
+	})
+	return r.saveIndexLocked()
+}
+
+func (r *Registry) root(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte(`<!doctype html><html><head><meta charset="utf-8"><title>QCAP Registry</title></head><body>
+		<h1>QCAP Registry (demo)</h1>
+		<p>This registry stores .qcap capsules on disk and persists a JSON index.</p>
+		<ul>
+			<li><a href="/health">/health</a> (JSON status)</li>
+			<li><a href="/health.html">/health.html</a> (HTML status)</li>
+			<li><a href="/index.json">/index.json</a> (JSON index)</li>
+			<li><a href="/index">/index</a> (HTML index)</li>
+			<li><a href="/artifacts/">/artifacts/</a> (downloads)</li>
+		</ul>
+	</body></html>`))
+}
+
+func (r *Registry) health(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"status":        "ok",
+		"auth_required": r.Token != "",
+		"artifacts":     len(r.Index),
+	})
+}
+
+func (r *Registry) healthHTML(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte(`<!doctype html><html><head><meta charset="utf-8"><title>Health</title></head><body>
+		<h1>Health</h1>
+		<p>The registry is running.</p>
+		<p>For machine-readable output, use <a href="/health">/health</a>.</p>
+	</body></html>`))
+}
+
+func (r *Registry) indexJSON(w http.ResponseWriter, _ *http.Request) {
+	_ = r.loadIndex()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(r.Index)
+}
+
+func (r *Registry) indexHTML(w http.ResponseWriter, _ *http.Request) {
+	_ = r.loadIndex()
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte("<!doctype html><html><head><meta charset=\"utf-8\"><title>Index</title></head><body>"))
+	_, _ = w.Write([]byte("<h1>Artifact Index</h1>\n"))
+	if len(r.Index) == 0 {
+		_, _ = w.Write([]byte("<p><em>No artifacts found.</em></p>"))
+	} else {
+		_, _ = w.Write([]byte("<ul>"))
+		for _, c := range r.Index {
+			_, _ = w.Write([]byte("<li>"))
+			_, _ = w.Write([]byte(c.Name))
+			_, _ = w.Write([]byte(" - <a href=\"" + c.Path + "\">download</a> (" + c.ContentType + ", " + formatSize(c.Size) + ", " + c.Digest + ")"))
+			_, _ = w.Write([]byte("</li>"))
+		}
+		_, _ = w.Write([]byte("</ul>"))
+	}
+	_, _ = w.Write([]byte("<p>Machine-readable index: <a href=\"/index.json\">/index.json</a></p>"))
+	_, _ = w.Write([]byte("</body></html>"))
+}
+
+func (r *Registry) publish(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !r.authorized(req) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	name := safeArtifactName(req.Header.Get("X-Qcap-Name"))
+	if name == "" {
+		name = "artifact.qcap"
+	}
+	if filepath.Ext(name) != ".qcap" {
+		name += ".qcap"
+	}
+	dest := filepath.Join(r.StoreDir, name)
+	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	out, err := os.Create(dest)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	written, copyErr := io.Copy(out, http.MaxBytesReader(w, req.Body, 512<<20))
+	closeErr := out.Close()
+	if copyErr != nil {
+		http.Error(w, copyErr.Error(), http.StatusBadRequest)
+		return
+	}
+	if closeErr != nil {
+		http.Error(w, closeErr.Error(), http.StatusInternalServerError)
+		return
+	}
+	digest, err := fileDigest(dest)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	capsule := Capsule{
+		Name:        name,
+		Path:        "/artifacts/" + name,
+		Size:        written,
+		ContentType: "application/qcap+zip",
+		Digest:      digest,
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := r.upsert(capsule); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(capsule)
+}
+
+func (r *Registry) artifact(w http.ResponseWriter, req *http.Request) {
+	name := safeArtifactName(strings.TrimPrefix(req.URL.Path, "/artifacts/"))
+	if name == "" {
+		http.NotFound(w, req)
+		return
+	}
+	http.ServeFile(w, req, filepath.Join(r.StoreDir, name))
+}
+
+func (r *Registry) authorized(req *http.Request) bool {
+	if r.Token == "" {
+		return true
+	}
+	return req.Header.Get("Authorization") == "Bearer "+r.Token
 }
 
 func safeArtifactName(raw string) string {
@@ -181,7 +307,28 @@ func safeArtifactName(raw string) string {
 	return name
 }
 
-// formatSize returns a human-readable byte size (e.g., 1.2 MB)
+func fileDigest(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
 func formatSize(n int64) string {
 	const (
 		KB = 1024

--- a/services/qcap-registry/main.go
+++ b/services/qcap-registry/main.go
@@ -3,10 +3,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type Capsule struct {
@@ -54,6 +56,9 @@ func main() {
 		seedDir = "services/qcap-registry/seed"
 	}
 	reg := &Registry{SeedDir: seedDir}
+	if err := os.MkdirAll(seedDir, 0755); err != nil {
+		log.Fatalf("could not create seed dir: %v", err)
+	}
 	if err := reg.loadIndex(); err != nil {
 		log.Printf("warn: could not load seed: %v", err)
 	}
@@ -97,12 +102,14 @@ func main() {
 
 	// JSON index endpoint
 	mux.HandleFunc("/index.json", func(w http.ResponseWriter, _ *http.Request) {
+		_ = reg.loadIndex()
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(reg.Index)
 	})
 
 	// HTML index page with description and simple listing
 	mux.HandleFunc("/index", func(w http.ResponseWriter, _ *http.Request) {
+		_ = reg.loadIndex()
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("<!doctype html><html><head><meta charset=\"utf-8\"><title>Index</title></head><body>"))
@@ -124,11 +131,54 @@ func main() {
 		w.Write([]byte("</body></html>"))
 	})
 
+	mux.HandleFunc("/artifacts", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		name := safeArtifactName(r.Header.Get("X-Qcap-Name"))
+		if name == "" {
+			name = "artifact.qcap"
+		}
+		if filepath.Ext(name) != ".qcap" {
+			name += ".qcap"
+		}
+		dest := filepath.Join(seedDir, name)
+		out, err := os.Create(dest)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer out.Close()
+		if _, err := io.Copy(out, http.MaxBytesReader(w, r.Body, 512<<20)); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		_ = reg.loadIndex()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(Capsule{
+			Name:        name,
+			Path:        "/artifacts/" + name,
+			ContentType: "application/qcap+zip",
+		})
+	})
+
 	mux.Handle("/artifacts/", http.StripPrefix("/artifacts/", http.FileServer(http.Dir(seedDir))))
 
 	addr := ":8080"
 	log.Printf("registry listening on %s; seed dir: %s", addr, seedDir)
 	log.Fatal(http.ListenAndServe(addr, mux))
+}
+
+func safeArtifactName(raw string) string {
+	name := filepath.Base(strings.TrimSpace(raw))
+	name = strings.ReplaceAll(name, "\\", "_")
+	name = strings.ReplaceAll(name, "/", "_")
+	if name == "." || name == string(filepath.Separator) {
+		return ""
+	}
+	return name
 }
 
 // formatSize returns a human-readable byte size (e.g., 1.2 MB)

--- a/services/qcap-registry/main_test.go
+++ b/services/qcap-registry/main_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPublishRequiresBearerTokenWhenConfigured(t *testing.T) {
+	dir := t.TempDir()
+	reg := &Registry{
+		StoreDir:  dir,
+		IndexPath: filepath.Join(dir, "index.json"),
+		Token:     "secret",
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/artifacts", bytes.NewReader([]byte("qcap")))
+	req.Header.Set("X-Qcap-Name", "demo.qcap")
+	rec := httptest.NewRecorder()
+	reg.publish(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected unauthorized, got %d", rec.Code)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "demo.qcap")); !os.IsNotExist(err) {
+		t.Fatalf("artifact should not be written without auth")
+	}
+}
+
+func TestPublishPersistsIndex(t *testing.T) {
+	dir := t.TempDir()
+	reg := &Registry{
+		StoreDir:  dir,
+		IndexPath: filepath.Join(dir, "index.json"),
+		Token:     "secret",
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/artifacts", bytes.NewReader([]byte("qcap")))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("X-Qcap-Name", "demo.qcap")
+	rec := httptest.NewRecorder()
+	reg.publish(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected created, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, "demo.qcap")); err != nil {
+		t.Fatalf("artifact not written: %v", err)
+	}
+
+	var persisted []Capsule
+	bytes, err := os.ReadFile(filepath.Join(dir, "index.json"))
+	if err != nil {
+		t.Fatalf("index not written: %v", err)
+	}
+	if err := json.Unmarshal(bytes, &persisted); err != nil {
+		t.Fatalf("index invalid JSON: %v", err)
+	}
+	if len(persisted) != 1 {
+		t.Fatalf("expected one capsule, got %d", len(persisted))
+	}
+	if persisted[0].Name != "demo.qcap" {
+		t.Fatalf("unexpected capsule name: %s", persisted[0].Name)
+	}
+	if persisted[0].Digest == "" || persisted[0].CreatedAt == "" {
+		t.Fatalf("expected digest and created_at in persisted index: %+v", persisted[0])
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a runnable Q-Cap MVP flow with identity generation, sealed .qcap packages, capability grants, open/verify/inspect, and registry publish/fetch.
- Adds GeoPackage demo fixture generation and verifies exported GeoPackage bytes.
- Adds signed revocations.json support, qcap revoke, open --revocations enforcement, token-protected registry publishing, and persistent registry index.json.
- Updates docs/demo scripts to match the current MVP behavior and avoid claiming Argon2id-protected keyfiles before that exists.

## Issue coverage
Addressed in this fork:
- #2 BLAKE3 payload Merkle tree
- #3 XChaCha20-Poly1305 envelope encryption
- #4 ed25519 signing and verification
- #6 .qcap ZIP writer/reader layout
- #8 revocations format and parser
- #10 qcap init
- #12 qcap seal
- #15 qcap revoke
- #17 qcap publish/fetch

Partially addressed:
- #23 bearer-token protection for publish endpoints is implemented; OIDC admin is still pending.

Not claimed:
- #24 revocations endpoint is not implemented yet; revocation files are local/CLI-enforced in this PR.

## Verification
- cargo fmt
- cargo check
- gofmt
- go test ./... in services/qcap-registry

Note: cargo test builds but this Windows machine blocks Rust test binary execution with Application Control policy error 4551, so full Rust test execution could not be completed locally.